### PR TITLE
Oauth 로그인 기능 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.5'
-    id 'io.spring.dependency-management' version '1.1.3'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 repositories {

--- a/gsmgogo-api/build.gradle
+++ b/gsmgogo-api/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     /* h2 */
     runtimeOnly 'com.h2database:h2'
 
+    /* redis */
+    implementation("org.springframework.session:spring-session-data-redis")
+    implementation 'io.lettuce:lettuce-core:6.2.3.RELEASE'
+
     implementation group: 'net.minidev', name: 'json-smart', version: '2.5.0'
 }
 

--- a/gsmgogo-api/build.gradle
+++ b/gsmgogo-api/build.gradle
@@ -1,6 +1,10 @@
 bootJar { enabled = true }
 jar { enabled = true }
 
+ext {
+    set('springCloudVersion', "2023.0.0")
+}
+
 dependencies {
     implementation project(':gsmgogo-entity')
 
@@ -11,6 +15,9 @@ dependencies {
 
     /* spring security */
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    /* feign */
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     /* jwt */
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
@@ -24,6 +31,12 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
 
     implementation group: 'net.minidev', name: 'json-smart', version: '2.5.0'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/gsmgogo-api/src/main/java/team/gsmgogo/GsmgogoApiApplication.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/GsmgogoApiApplication.java
@@ -2,7 +2,9 @@ package team.gsmgogo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class GsmgogoApiApplication {
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -38,7 +38,6 @@ public class AuthController {
     @Value("${spring.jwt.refreshExp}")
     public Long refreshExp;
 
-
     @GetMapping("/login")
     public void login(HttpServletResponse response) throws IOException {
         String loginUrl = "https://gauth.co.kr/login?" +

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -1,0 +1,32 @@
+package team.gsmgogo.domain.auth.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    @Value("${gauth.clientId}")
+    private String clientId;
+
+    @Value("${gauth.redirectUrl}")
+    private String redirectUri;
+
+    @GetMapping("/login")
+    public void login(HttpServletResponse response) throws IOException {
+         String loginUrl = "https://gauth.co.kr/login?" +
+                    "client_id=" + clientId + "&" +
+                    "redirect_uri=" + redirectUri;
+
+         response.sendRedirect(loginUrl);
+    }
+
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import team.gsmgogo.domain.auth.controller.dto.response.AuthCallBackCodeResponse;
 import team.gsmgogo.domain.auth.controller.dto.response.TokenDto;
 import team.gsmgogo.domain.auth.service.GauthLoginService;
-import team.gsmgogo.global.feign.dto.GauthTokenDto;
+import team.gsmgogo.global.facade.UserFacade;
 import team.gsmgogo.global.manager.CookieManager;
 import team.gsmgogo.global.security.jwt.JwtTokenProvider;
 
@@ -24,6 +24,7 @@ public class AuthController {
 
     private final GauthLoginService gauthLoginService;
     private final CookieManager cookieManager;
+    private final UserFacade userFacade;
 
     @Value("${gauth.clientId}")
     private String clientId;
@@ -37,15 +38,15 @@ public class AuthController {
 
     @GetMapping("/login")
     public void login(HttpServletResponse response) throws IOException {
-         String loginUrl = "https://gauth.co.kr/login?" +
-                    "client_id=" + clientId + "&" +
-                    "redirect_uri=" + redirectUri;
+        String loginUrl = "https://gauth.co.kr/login?" +
+                "client_id=" + clientId + "&" +
+                "redirect_uri=" + redirectUri;
 
-         response.sendRedirect(loginUrl);
+        response.sendRedirect(loginUrl);
     }
 
     @GetMapping("/callback")
-    public ResponseEntity<AuthCallBackCodeResponse> callback(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
+    public ResponseEntity<AuthCallBackCodeResponse> callback(@RequestParam("code") String code, HttpServletResponse response) {
         TokenDto tokenDto = gauthLoginService.execute(code);
         cookieManager.addTokenCookie(response, JwtTokenProvider.ACCESS_KEY, tokenDto.getAccessToken(), accessExp, true);
         cookieManager.addTokenCookie(response, JwtTokenProvider.REFRESH_KEY, tokenDto.getRefreshToken(), refreshExp, true);

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 import team.gsmgogo.domain.auth.controller.dto.response.AuthCallBackCodeResponse;
 import team.gsmgogo.domain.auth.controller.dto.response.TokenDto;
 import team.gsmgogo.domain.auth.service.GauthLoginService;
-import team.gsmgogo.global.facade.UserFacade;
 import team.gsmgogo.global.manager.CookieManager;
 import team.gsmgogo.global.security.jwt.JwtTokenProvider;
 
@@ -24,7 +23,6 @@ public class AuthController {
 
     private final GauthLoginService gauthLoginService;
     private final CookieManager cookieManager;
-    private final UserFacade userFacade;
 
     @Value("${gauth.clientId}")
     private String clientId;

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -7,12 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import team.gsmgogo.global.feign.GauthClient;
-import team.gsmgogo.global.feign.dto.GauthTokenDto;
-import team.gsmgogo.global.feign.dto.GauthTokenRequest;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 
 @RestController
@@ -20,16 +16,6 @@ import java.net.URISyntaxException;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final GauthClient gauthClient;
-
-    @Value("${gauth.clientId}")
-    private String clientId;
-
-    @Value("${gauth.clientSecret}")
-    private String clientSecret;
-
-    @Value("${gauth.redirectUrl}")
-    private String redirectUri;
 
     @GetMapping("/login")
     public void login(HttpServletResponse response) throws IOException {
@@ -42,12 +28,8 @@ public class AuthController {
 
     @GetMapping("/callback")
     public void callback(@RequestParam("code") String code) throws URISyntaxException {
-        GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI("https://server.gauth.co.kr/oauth/token"), GauthTokenRequest.builder()
-                        .code(code)
-                        .clientId("83826b547e88434eb1a6dfc27c2ba7f9d877615fc09a438c8703fbbea15a202e")
-                        .clientSecret("9e01491916754f078ddd54c37b6e2ceca5567d5e961c41d8915fb67aae90e9b8")
-                        .redirectUri("http://localhost:8080/auth/callback")
-                .build());
+
+
     }
 
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -16,7 +16,6 @@ import team.gsmgogo.domain.auth.service.GauthLoginService;
 import team.gsmgogo.domain.auth.service.TokenReissueService;
 import team.gsmgogo.global.manager.CookieManager;
 import team.gsmgogo.global.security.jwt.JwtTokenProvider;
-import team.gsmgogo.global.security.jwt.dto.TokenResponse;
 
 import java.io.IOException;
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import team.gsmgogo.domain.auth.service.GauthLoginService;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -15,6 +16,14 @@ import java.net.URISyntaxException;
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
+    private final GauthLoginService gauthLoginService;
+
+    @Value("${gauth.clientId}")
+    private String clientId;
+
+    @Value("${gauth.redirectUrl}")
+    private String redirectUri;
 
 
     @GetMapping("/login")
@@ -28,7 +37,7 @@ public class AuthController {
 
     @GetMapping("/callback")
     public void callback(@RequestParam("code") String code) throws URISyntaxException {
-
+        gauthLoginService.execute(code);
 
     }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -5,17 +5,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import team.gsmgogo.global.feign.GauthClient;
+import team.gsmgogo.global.feign.dto.GauthTokenDto;
+import team.gsmgogo.global.feign.dto.GauthTokenRequest;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final GauthClient gauthClient;
+
     @Value("${gauth.clientId}")
     private String clientId;
+
+    @Value("${gauth.clientSecret}")
+    private String clientSecret;
 
     @Value("${gauth.redirectUrl}")
     private String redirectUri;
@@ -27,6 +38,16 @@ public class AuthController {
                     "redirect_uri=" + redirectUri;
 
          response.sendRedirect(loginUrl);
+    }
+
+    @GetMapping("/callback")
+    public void callback(@RequestParam("code") String code) throws URISyntaxException {
+        GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI("https://server.gauth.co.kr/oauth/token"), GauthTokenRequest.builder()
+                        .code(code)
+                        .clientId("83826b547e88434eb1a6dfc27c2ba7f9d877615fc09a438c8703fbbea15a202e")
+                        .clientSecret("9e01491916754f078ddd54c37b6e2ceca5567d5e961c41d8915fb67aae90e9b8")
+                        .redirectUri("http://localhost:8080/auth/callback")
+                .build());
     }
 
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.gsmgogo.domain.auth.service.GauthLoginService;
+import team.gsmgogo.global.feign.dto.GauthTokenDto;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -36,8 +37,9 @@ public class AuthController {
     }
 
     @GetMapping("/callback")
-    public void callback(@RequestParam("code") String code) throws URISyntaxException {
-        gauthLoginService.execute(code);
+    public void callback(@RequestParam("code") String code)  {
+        GauthTokenDto gauthTokenDto = gauthLoginService.execute(code);
+        System.out.println("gauthTokenDto.getAccessToken() = " + gauthTokenDto.getAccessToken());
 
     }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/dto/response/AuthCallBackCodeResponse.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/dto/response/AuthCallBackCodeResponse.java
@@ -1,4 +1,4 @@
-package team.gsmgogo.global.feign.dto;
+package team.gsmgogo.domain.auth.controller.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,6 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class GauthTokenDto {
-    private String accessToken;
+public class AuthCallBackCodeResponse {
+    private Boolean isSignup;
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/dto/response/ReissueTokenDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/dto/response/ReissueTokenDto.java
@@ -1,0 +1,13 @@
+package team.gsmgogo.domain.auth.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReissueTokenDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/dto/response/TokenDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/controller/dto/response/TokenDto.java
@@ -1,0 +1,12 @@
+package team.gsmgogo.domain.auth.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+    private Boolean isSignup;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/repository/RefreshTokenJpaRepository.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/repository/RefreshTokenJpaRepository.java
@@ -6,5 +6,5 @@ import team.gsmgogo.domain.auth.entity.RefreshTokenRedisEntity;
 import java.util.Optional;
 
 public interface RefreshTokenJpaRepository extends CrudRepository<RefreshTokenRedisEntity, Long> {
-    Optional<RefreshTokenRedisEntity> findByUserSeq(Long userSeq);
+    Optional<RefreshTokenRedisEntity> findByUserId(Long userId);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/repository/RefreshTokenJpaRepository.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/repository/RefreshTokenJpaRepository.java
@@ -1,0 +1,10 @@
+package team.gsmgogo.domain.auth.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import team.gsmgogo.domain.auth.entity.RefreshTokenRedisEntity;
+
+import java.util.Optional;
+
+public interface RefreshTokenJpaRepository extends CrudRepository<RefreshTokenRedisEntity, String> {
+    Optional<RefreshTokenRedisEntity> findByUserEmail(String email);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/repository/RefreshTokenJpaRepository.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/repository/RefreshTokenJpaRepository.java
@@ -5,6 +5,6 @@ import team.gsmgogo.domain.auth.entity.RefreshTokenRedisEntity;
 
 import java.util.Optional;
 
-public interface RefreshTokenJpaRepository extends CrudRepository<RefreshTokenRedisEntity, String> {
-    Optional<RefreshTokenRedisEntity> findByUserEmail(String email);
+public interface RefreshTokenJpaRepository extends CrudRepository<RefreshTokenRedisEntity, Long> {
+    Optional<RefreshTokenRedisEntity> findByUserSeq(Long userSeq);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
@@ -1,7 +1,7 @@
 package team.gsmgogo.domain.auth.service;
 
-import java.net.URISyntaxException;
+import team.gsmgogo.global.feign.dto.GauthTokenDto;
 
 public interface GauthLoginService {
-    void execute(String code) throws URISyntaxException;
+    GauthTokenDto execute(String code);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
@@ -1,7 +1,6 @@
 package team.gsmgogo.domain.auth.service;
 
 import team.gsmgogo.domain.auth.controller.dto.response.TokenDto;
-import team.gsmgogo.global.feign.dto.GauthTokenDto;
 
 public interface GauthLoginService {
     TokenDto execute(String code);

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
@@ -1,7 +1,8 @@
 package team.gsmgogo.domain.auth.service;
 
+import team.gsmgogo.domain.auth.controller.dto.response.TokenDto;
 import team.gsmgogo.global.feign.dto.GauthTokenDto;
 
 public interface GauthLoginService {
-    GauthTokenDto execute(String code);
+    TokenDto execute(String code);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
@@ -1,0 +1,5 @@
+package team.gsmgogo.domain.auth.service;
+
+public interface GauthLoginService {
+    public void execute(String code);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/GauthLoginService.java
@@ -1,5 +1,7 @@
 package team.gsmgogo.domain.auth.service;
 
+import java.net.URISyntaxException;
+
 public interface GauthLoginService {
-    public void execute(String code);
+    void execute(String code) throws URISyntaxException;
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/TokenReissueService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/TokenReissueService.java
@@ -1,0 +1,7 @@
+package team.gsmgogo.domain.auth.service;
+
+import team.gsmgogo.domain.auth.controller.dto.response.ReissueTokenDto;
+
+public interface TokenReissueService {
+    ReissueTokenDto execute(String refreshToken);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -2,22 +2,36 @@ package team.gsmgogo.domain.auth.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.gsmgogo.domain.auth.service.GauthLoginService;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.enums.ClassEnum;
+import team.gsmgogo.domain.user.enums.GradeEnum;
+import team.gsmgogo.domain.user.enums.Role;
+import team.gsmgogo.domain.user.enums.SchoolRole;
+import team.gsmgogo.domain.user.repository.UserJpaRepository;
+import team.gsmgogo.global.exception.error.ExpectedException;
 import team.gsmgogo.global.feign.GauthClient;
 import team.gsmgogo.global.feign.dto.GauthTokenDto;
 import team.gsmgogo.global.feign.dto.GauthTokenRequest;
 import team.gsmgogo.global.feign.dto.GauthUserDto;
+import team.gsmgogo.global.feign.dto.UserSchoolRole;
+import team.gsmgogo.global.security.jwt.JwtTokenProvider;
+import team.gsmgogo.global.security.jwt.dto.TokenResponse;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class GauthLoginServiceImpl implements GauthLoginService {
 
     private final GauthClient gauthClient;
+    private final UserJpaRepository userJpaRepository;
+    private final JwtTokenProvider tokenProvider;
 
     @Value("${gauth.clientId}")
     private String clientId;
@@ -30,17 +44,68 @@ public class GauthLoginServiceImpl implements GauthLoginService {
 
     @Override
     @Transactional
-    public void execute(String code) throws URISyntaxException {
+    public GauthTokenDto execute(String code) {
 
-        GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI("https://server.gauth.co.kr/oauth/token"), GauthTokenRequest.builder()
-                .code(code)
-                .clientId(clientId)
-                .clientSecret(clientSecret)
-                .redirectUri(redirectUri)
-                .build());
+        try {
+
+            GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI("https://server.gauth.co.kr/oauth/token"), GauthTokenRequest.builder()
+                    .code(code)
+                    .clientId(clientId)
+                    .clientSecret(clientSecret)
+                    .redirectUri(redirectUri)
+                    .build());
 
 
-        GauthUserDto gauthUserDto = gauthClient.getInfo(new URI("https://open.gauth.co.kr/user"), "Bearer " + gauthTokenDto.getAccessToken());
+            GauthUserDto gauthUserDto = gauthClient.getInfo(new URI("https://open.gauth.co.kr/user"), "Bearer " + gauthTokenDto.getAccessToken());
+
+            Integer grade = gauthUserDto.getGrade();
+            Integer classNum = gauthUserDto.getClassNum();
+            UserSchoolRole userSchoolRole = gauthUserDto.getRole();
+            String email = gauthUserDto.getEmail();
+
+            UserEntity currentUser = userJpaRepository.findByUserEmail(gauthUserDto.getEmail()).orElse(null);
+
+            if (currentUser == null) {
+                UserEntity newUser = UserEntity.builder()
+                        .userEmail(email)
+                        .userGrade(
+                            switch (grade) {
+                                case 1 -> GradeEnum.ONE;
+                                case 2 -> GradeEnum.TWO;
+                                case 3 -> GradeEnum.THREE;
+                                default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+                            }
+                        )
+                        .userClass(
+                            switch (classNum) {
+                                case 1 -> ClassEnum.ONE;
+                                case 2 -> ClassEnum.TWO;
+                                case 3 -> ClassEnum.THREE;
+                                case 4 -> ClassEnum.FOUR;
+                                default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+                            }
+                        )
+                        .schoolRole(
+                                switch (userSchoolRole) {
+                                    case ROLE_STUDENT -> SchoolRole.STUDENT;
+                                    case ROLE_TEACHER -> SchoolRole.TEACHER;
+                                }
+
+                        )
+                        .role(Role.USER)
+                        .point(30000).build();
+
+                userJpaRepository.save(newUser);
+            }
+
+            TokenResponse token = tokenProvider.getToken(email);
+
+            return new GauthTokenDto(token.getAccessToken(), token.getRefreshToken());
+
+        } catch (Exception e) {
+            throw new ExpectedException("Gauth 외부 API 호출중 에러가 발생했어요!", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
 
     }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -1,0 +1,42 @@
+package team.gsmgogo.domain.auth.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.gsmgogo.domain.auth.service.GauthLoginService;
+import team.gsmgogo.global.feign.GauthClient;
+import team.gsmgogo.global.feign.dto.GauthTokenDto;
+import team.gsmgogo.global.feign.dto.GauthTokenRequest;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class GauthLoginServiceImpl implements GauthLoginService {
+
+    private final GauthClient gauthClient;
+
+    @Value("${gauth.clientId}")
+    private String clientId;
+
+    @Value("${gauth.clientSecret}")
+    private String clientSecret;
+
+    @Value("${gauth.redirectUrl}")
+    private String redirectUri;
+
+    @Override
+    @Transactional
+    public void execute(String code) {
+
+        GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI("https://server.gauth.co.kr/oauth/token"), GauthTokenRequest.builder()
+                .code(code)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .redirectUri(redirectUri)
+                .build());
+
+    }
+
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -77,7 +77,7 @@ public class GauthLoginServiceImpl implements GauthLoginService {
                             case 1 -> GradeEnum.ONE;
                             case 2 -> GradeEnum.TWO;
                             case 3 -> GradeEnum.THREE;
-                            default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+                            default -> throw new ExpectedException("유저의 학년을 엔티티와 매핑시키는 도중 발생한 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
                         }
                     )
                     .userClass(
@@ -86,7 +86,7 @@ public class GauthLoginServiceImpl implements GauthLoginService {
                             case 2 -> ClassEnum.TWO;
                             case 3 -> ClassEnum.THREE;
                             case 4 -> ClassEnum.FOUR;
-                            default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+                            default -> throw new ExpectedException("유저의 반을 엔티티와 매핑시키는 도중 발생한 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
                         }
                     )
                     .schoolRole(

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -61,12 +61,14 @@ public class GauthLoginServiceImpl implements GauthLoginService {
             Integer grade = gauthUserDto.getGrade();
             Integer classNum = gauthUserDto.getClassNum();
             UserSchoolRole userSchoolRole = gauthUserDto.getRole();
+            String name = gauthUserDto.getName();
             String email = gauthUserDto.getEmail();
 
             UserEntity currentUser = userJpaRepository.findByUserEmail(gauthUserDto.getEmail()).orElse(null);
 
             if (currentUser == null) {
                 UserEntity newUser = UserEntity.builder()
+                        .userName(name)
                         .userEmail(email)
                         .userGrade(
                             switch (grade) {

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -71,6 +71,7 @@ public class GauthLoginServiceImpl implements GauthLoginService {
             UserEntity currentUser = userJpaRepository.findByUserEmail(gauthUserDto.getEmail()).orElse(null);
 
             boolean isSignedUp = true;
+            long userSeq;
 
             if (currentUser == null) {
                 UserEntity newUser = UserEntity.builder()
@@ -103,17 +104,20 @@ public class GauthLoginServiceImpl implements GauthLoginService {
                         .role(Role.USER)
                         .point(30000).build();
 
-                userJpaRepository.save(newUser);
+                userSeq = userJpaRepository.save(newUser).getUserSeq();
 
                 isSignedUp = false;
             } else if (currentUser.getPhoneNumber().isEmpty()) {
                 isSignedUp = false;
+                userSeq = currentUser.getUserSeq();
+            } else {
+                userSeq = currentUser.getUserSeq();
             }
 
-            TokenResponse token = tokenProvider.getToken(email);
+            TokenResponse token = tokenProvider.getToken(userSeq);
 
             RefreshTokenRedisEntity refreshToken = RefreshTokenRedisEntity.builder()
-                    .userEmail(email)
+                    .userSeq(userSeq)
                     .refreshToken(token.getRefreshToken())
                     .expiredAt(refreshExp).build();
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -8,8 +8,10 @@ import team.gsmgogo.domain.auth.service.GauthLoginService;
 import team.gsmgogo.global.feign.GauthClient;
 import team.gsmgogo.global.feign.dto.GauthTokenDto;
 import team.gsmgogo.global.feign.dto.GauthTokenRequest;
+import team.gsmgogo.global.feign.dto.GauthUserDto;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +30,7 @@ public class GauthLoginServiceImpl implements GauthLoginService {
 
     @Override
     @Transactional
-    public void execute(String code) {
+    public void execute(String code) throws URISyntaxException {
 
         GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI("https://server.gauth.co.kr/oauth/token"), GauthTokenRequest.builder()
                 .code(code)
@@ -36,6 +38,9 @@ public class GauthLoginServiceImpl implements GauthLoginService {
                 .clientSecret(clientSecret)
                 .redirectUri(redirectUri)
                 .build());
+
+
+        GauthUserDto gauthUserDto = gauthClient.getInfo(new URI("https://open.gauth.co.kr/user"), "Bearer " + gauthTokenDto.getAccessToken());
 
     }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -16,7 +16,8 @@ import team.gsmgogo.domain.user.enums.Role;
 import team.gsmgogo.domain.user.enums.SchoolRole;
 import team.gsmgogo.domain.user.repository.UserJpaRepository;
 import team.gsmgogo.global.exception.error.ExpectedException;
-import team.gsmgogo.global.feign.GauthClient;
+import team.gsmgogo.global.feign.GauthInfo;
+import team.gsmgogo.global.feign.GauthToken;
 import team.gsmgogo.global.feign.dto.GauthTokenDto;
 import team.gsmgogo.global.feign.dto.GauthTokenRequest;
 import team.gsmgogo.global.feign.dto.GauthUserDto;
@@ -24,13 +25,12 @@ import team.gsmgogo.global.feign.dto.UserSchoolRole;
 import team.gsmgogo.global.security.jwt.JwtTokenProvider;
 import team.gsmgogo.global.security.jwt.dto.TokenResponse;
 
-import java.net.URI;
-
 @Service
 @RequiredArgsConstructor
 public class GauthLoginServiceImpl implements GauthLoginService {
 
-    private final GauthClient gauthClient;
+    private final GauthToken gauthToken;
+    private final GauthInfo gauthInfo;
     private final UserJpaRepository userJpaRepository;
     private final JwtTokenProvider tokenProvider;
     private final RefreshTokenJpaRepository refreshTokenJpaRepository;
@@ -43,91 +43,82 @@ public class GauthLoginServiceImpl implements GauthLoginService {
     private String clientSecret;
     @Value("${gauth.redirectUrl}")
     private String redirectUri;
-    @Value("${gauth.authUrl}")
-    public String authUrl;
-    @Value("${gauth.userApiUrl}")
-    public String userApiUrl;
 
     @Override
     @Transactional
     public TokenDto execute(String code) {
 
-        try {
-            GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI(authUrl), GauthTokenRequest.builder()
-                    .code(code)
-                    .clientId(clientId)
-                    .clientSecret(clientSecret)
-                    .redirectUri(redirectUri)
-                    .build());
+        GauthTokenDto gauthTokenDto = gauthToken.getToken(GauthTokenRequest.builder()
+                .code(code)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .redirectUri(redirectUri)
+                .build());
 
-            GauthUserDto gauthUserDto = gauthClient.getInfo(new URI(userApiUrl), "Bearer " + gauthTokenDto.getAccessToken());
+        GauthUserDto gauthUserDto = gauthInfo.getInfo("Bearer " + gauthTokenDto.getAccessToken());
 
-            Integer grade = gauthUserDto.getGrade();
-            Integer classNum = gauthUserDto.getClassNum();
-            UserSchoolRole userSchoolRole = gauthUserDto.getRole();
-            String name = gauthUserDto.getName();
-            String email = gauthUserDto.getEmail();
+        Integer grade = gauthUserDto.getGrade();
+        Integer classNum = gauthUserDto.getClassNum();
+        UserSchoolRole userSchoolRole = gauthUserDto.getRole();
+        String name = gauthUserDto.getName();
+        String email = gauthUserDto.getEmail();
 
-            UserEntity currentUser = userJpaRepository.findByUserEmail(gauthUserDto.getEmail()).orElse(null);
+        UserEntity currentUser = userJpaRepository.findByUserEmail(gauthUserDto.getEmail()).orElse(null);
 
-            boolean isSignedUp = true;
-            long userSeq;
+        boolean isSignedUp = true;
+        long userSeq;
 
-            if (currentUser == null) {
-                UserEntity newUser = UserEntity.builder()
-                        .userName(name)
-                        .userEmail(email)
-                        .userGrade(
-                            switch (grade) {
-                                case 1 -> GradeEnum.ONE;
-                                case 2 -> GradeEnum.TWO;
-                                case 3 -> GradeEnum.THREE;
-                                default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+        if (currentUser == null) {
+            UserEntity newUser = UserEntity.builder()
+                    .userName(name)
+                    .userEmail(email)
+                    .userGrade(
+                        switch (grade) {
+                            case 1 -> GradeEnum.ONE;
+                            case 2 -> GradeEnum.TWO;
+                            case 3 -> GradeEnum.THREE;
+                            default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+                        }
+                    )
+                    .userClass(
+                        switch (classNum) {
+                            case 1 -> ClassEnum.ONE;
+                            case 2 -> ClassEnum.TWO;
+                            case 3 -> ClassEnum.THREE;
+                            case 4 -> ClassEnum.FOUR;
+                            default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
+                        }
+                    )
+                    .schoolRole(
+                            switch (userSchoolRole) {
+                                case ROLE_STUDENT -> SchoolRole.STUDENT;
+                                case ROLE_TEACHER -> SchoolRole.TEACHER;
                             }
-                        )
-                        .userClass(
-                            switch (classNum) {
-                                case 1 -> ClassEnum.ONE;
-                                case 2 -> ClassEnum.TWO;
-                                case 3 -> ClassEnum.THREE;
-                                case 4 -> ClassEnum.FOUR;
-                                default -> throw new ExpectedException("유저 엔티티 저장을 위한 매핑중 발생한 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
-                            }
-                        )
-                        .schoolRole(
-                                switch (userSchoolRole) {
-                                    case ROLE_STUDENT -> SchoolRole.STUDENT;
-                                    case ROLE_TEACHER -> SchoolRole.TEACHER;
-                                }
 
-                        )
-                        .role(Role.USER)
-                        .point(30000).build();
+                    )
+                    .role(Role.USER)
+                    .point(30000).build();
 
-                userSeq = userJpaRepository.save(newUser).getUserSeq();
+            userSeq = userJpaRepository.save(newUser).getUserSeq();
 
-                isSignedUp = false;
-            } else if (currentUser.getPhoneNumber().isEmpty()) {
-                isSignedUp = false;
-                userSeq = currentUser.getUserSeq();
-            } else {
-                userSeq = currentUser.getUserSeq();
-            }
-
-            TokenResponse token = tokenProvider.getToken(userSeq);
-
-            RefreshTokenRedisEntity refreshToken = RefreshTokenRedisEntity.builder()
-                    .userSeq(userSeq)
-                    .refreshToken(token.getRefreshToken())
-                    .expiredAt(refreshExp).build();
-
-            String savedRefreshToken = refreshTokenJpaRepository.save(refreshToken).getRefreshToken();
-
-            return new TokenDto(token.getAccessToken(), savedRefreshToken, isSignedUp);
-
-        } catch (Exception e) {
-            throw new ExpectedException("Gauth 외부 API 호출중 에러가 발생했어요!", HttpStatus.INTERNAL_SERVER_ERROR);
+            isSignedUp = false;
+        } else if (currentUser.getPhoneNumber().isEmpty()) {
+            isSignedUp = false;
+            userSeq = currentUser.getUserSeq();
+        } else {
+            userSeq = currentUser.getUserSeq();
         }
+
+        TokenResponse token = tokenProvider.getToken(userSeq);
+
+        RefreshTokenRedisEntity refreshToken = RefreshTokenRedisEntity.builder()
+                .userSeq(userSeq)
+                .refreshToken(token.getRefreshToken())
+                .expiredAt(refreshExp).build();
+
+        String savedRefreshToken = refreshTokenJpaRepository.save(refreshToken).getRefreshToken();
+
+        return new TokenDto(token.getAccessToken(), savedRefreshToken, isSignedUp);
 
     }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -66,7 +66,7 @@ public class GauthLoginServiceImpl implements GauthLoginService {
         UserEntity currentUser = userJpaRepository.findByUserEmail(gauthUserDto.getEmail()).orElse(null);
 
         boolean isSignedUp = true;
-        long userSeq;
+        long userId;
 
         if (currentUser == null) {
             UserEntity newUser = UserEntity.builder()
@@ -99,20 +99,20 @@ public class GauthLoginServiceImpl implements GauthLoginService {
                     .role(Role.USER)
                     .point(30000).build();
 
-            userSeq = userJpaRepository.save(newUser).getUserSeq();
+            userId = userJpaRepository.save(newUser).getUserId();
 
             isSignedUp = false;
         } else if (currentUser.getPhoneNumber().isEmpty()) {
             isSignedUp = false;
-            userSeq = currentUser.getUserSeq();
+            userId = currentUser.getUserId();
         } else {
-            userSeq = currentUser.getUserSeq();
+            userId = currentUser.getUserId();
         }
 
-        TokenResponse token = tokenProvider.getToken(userSeq);
+        TokenResponse token = tokenProvider.getToken(userId);
 
         RefreshTokenRedisEntity refreshToken = RefreshTokenRedisEntity.builder()
-                .userSeq(userSeq)
+                .userId(userId)
                 .refreshToken(token.getRefreshToken())
                 .expiredAt(refreshExp).build();
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -34,26 +34,28 @@ public class GauthLoginServiceImpl implements GauthLoginService {
 
     @Value("${gauth.clientId}")
     private String clientId;
-
     @Value("${gauth.clientSecret}")
     private String clientSecret;
-
     @Value("${gauth.redirectUrl}")
     private String redirectUri;
+    @Value("${gauth.authUrl}")
+    public String authUrl;
+    @Value("${gauth.userApiUrl}")
+    public String userApiUrl;
 
     @Override
     @Transactional
     public TokenDto execute(String code) {
 
         try {
-            GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI("https://server.gauth.co.kr/oauth/token"), GauthTokenRequest.builder()
+            GauthTokenDto gauthTokenDto = gauthClient.getToken(new URI(authUrl), GauthTokenRequest.builder()
                     .code(code)
                     .clientId(clientId)
                     .clientSecret(clientSecret)
                     .redirectUri(redirectUri)
                     .build());
 
-            GauthUserDto gauthUserDto = gauthClient.getInfo(new URI("https://open.gauth.co.kr/user"), "Bearer " + gauthTokenDto.getAccessToken());
+            GauthUserDto gauthUserDto = gauthClient.getInfo(new URI(userApiUrl), "Bearer " + gauthTokenDto.getAccessToken());
 
             Integer grade = gauthUserDto.getGrade();
             Integer classNum = gauthUserDto.getClassNum();

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/TokenReissueServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/TokenReissueServiceImpl.java
@@ -1,0 +1,51 @@
+package team.gsmgogo.domain.auth.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import team.gsmgogo.domain.auth.controller.dto.response.ReissueTokenDto;
+import team.gsmgogo.domain.auth.entity.RefreshTokenRedisEntity;
+import team.gsmgogo.domain.auth.repository.RefreshTokenJpaRepository;
+import team.gsmgogo.domain.auth.service.TokenReissueService;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.repository.UserJpaRepository;
+import team.gsmgogo.global.exception.error.ExpectedException;
+import team.gsmgogo.global.security.jwt.JwtTokenProvider;
+import team.gsmgogo.global.security.jwt.dto.TokenResponse;
+
+@Service
+@RequiredArgsConstructor
+public class TokenReissueServiceImpl implements TokenReissueService {
+
+    private final RefreshTokenJpaRepository refreshTokenJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final JwtTokenProvider tokenProvider;
+
+    @Override
+    public ReissueTokenDto execute(String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new ExpectedException("리프레시 토큰을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        long userSeq = Long.parseLong(tokenProvider.getRefreshTokenUserSeq(refreshToken));
+        UserEntity user = userJpaRepository.findByUserSeq(userSeq)
+                .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        RefreshTokenRedisEntity currentRefreshToken = refreshTokenJpaRepository.findByUserSeq(user.getUserSeq())
+                .orElseThrow(() -> new ExpectedException("리프레시 토큰이 유효하지 않습니다.", HttpStatus.NOT_FOUND));
+
+        TokenResponse newToken = tokenProvider.getToken(userSeq);
+
+        if (!user.getUserSeq().equals(currentRefreshToken.getUserSeq()) || !currentRefreshToken.getRefreshToken().equals(refreshToken)) {
+            throw new ExpectedException("리프레시 토큰이 유효하지 않습니다.", HttpStatus.NOT_FOUND);
+        }
+
+
+        currentRefreshToken.updateRefreshToken(newToken.getRefreshToken());
+        refreshTokenJpaRepository.save(currentRefreshToken);
+
+        return new ReissueTokenDto(newToken.getAccessToken(), newToken.getRefreshToken());
+
+    }
+
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/TokenReissueServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/TokenReissueServiceImpl.java
@@ -40,7 +40,6 @@ public class TokenReissueServiceImpl implements TokenReissueService {
             throw new ExpectedException("리프레시 토큰이 유효하지 않습니다.", HttpStatus.NOT_FOUND);
         }
 
-
         currentRefreshToken.updateRefreshToken(newToken.getRefreshToken());
         refreshTokenJpaRepository.save(currentRefreshToken);
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/TokenReissueServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/TokenReissueServiceImpl.java
@@ -28,15 +28,15 @@ public class TokenReissueServiceImpl implements TokenReissueService {
             throw new ExpectedException("리프레시 토큰을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
 
-        long userSeq = Long.parseLong(tokenProvider.getRefreshTokenUserSeq(refreshToken));
-        UserEntity user = userJpaRepository.findByUserSeq(userSeq)
+        long userId = Long.parseLong(tokenProvider.getRefreshTokenUserId(refreshToken));
+        UserEntity user = userJpaRepository.findByUserId(userId)
                 .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
-        RefreshTokenRedisEntity currentRefreshToken = refreshTokenJpaRepository.findByUserSeq(user.getUserSeq())
+        RefreshTokenRedisEntity currentRefreshToken = refreshTokenJpaRepository.findByUserId(user.getUserId())
                 .orElseThrow(() -> new ExpectedException("리프레시 토큰이 유효하지 않습니다.", HttpStatus.NOT_FOUND));
 
-        TokenResponse newToken = tokenProvider.getToken(userSeq);
+        TokenResponse newToken = tokenProvider.getToken(userId);
 
-        if (!user.getUserSeq().equals(currentRefreshToken.getUserSeq()) || !currentRefreshToken.getRefreshToken().equals(refreshToken)) {
+        if (!user.getUserId().equals(currentRefreshToken.getUserId()) || !currentRefreshToken.getRefreshToken().equals(refreshToken)) {
             throw new ExpectedException("리프레시 토큰이 유효하지 않습니다.", HttpStatus.NOT_FOUND);
         }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUserEmail(String userEmail);
+    Optional<UserEntity> findByUserSeq(Long userSeq);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUserEmail(String userEmail);
-    Optional<UserEntity> findByUserSeq(Long userSeq);
+    Optional<UserEntity> findByUserId(Long id);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/config/GauthFeignConfig.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/config/GauthFeignConfig.java
@@ -1,0 +1,13 @@
+package team.gsmgogo.global.config;
+
+import feign.Client;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GauthFeignConfig {
+    @Bean
+    public Client feignClient() {
+        return new Client.Default(null, null);
+    }
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/config/GauthFeignConfig.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/config/GauthFeignConfig.java
@@ -1,13 +1,18 @@
 package team.gsmgogo.global.config;
 
-import feign.Client;
+import feign.codec.ErrorDecoder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import team.gsmgogo.global.feign.FeignClientErrorDecoder;
 
+@Import(FeignClientErrorDecoder.class)
 @Configuration
 public class GauthFeignConfig {
     @Bean
-    public Client feignClient() {
-        return new Client.Default(null, null);
+    @ConditionalOnMissingBean(value = ErrorDecoder.class)
+    public FeignClientErrorDecoder commonFeignErrorDecoder() {
+        return new FeignClientErrorDecoder();
     }
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/config/RedisConfig.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package team.gsmgogo.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 300)
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private Integer port;
+
+    @Bean
+    @ConditionalOnMissingBean(RedisConnectionFactory.class)
+    RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    RedisTemplate<String, Object> redisTemplate(){
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(RedisSerializer.string());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}
+

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/facade/UserFacade.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/facade/UserFacade.java
@@ -22,4 +22,5 @@ public class UserFacade {
         return userJpaRepository.findByUserEmail(email)
                 .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
     }
+
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/facade/UserFacade.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/facade/UserFacade.java
@@ -1,0 +1,25 @@
+package team.gsmgogo.global.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.repository.UserJpaRepository;
+import team.gsmgogo.global.exception.error.ExpectedException;
+
+@Configuration
+@RequiredArgsConstructor
+public class UserFacade {
+    private final UserJpaRepository userJpaRepository;
+
+    public UserEntity getCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return getUserByEmail(email);
+    }
+
+    public UserEntity getUserByEmail(String email) {
+        return userJpaRepository.findByUserEmail(email)
+                .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+    }
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/FeignClientErrorDecoder.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/FeignClientErrorDecoder.java
@@ -1,0 +1,20 @@
+package team.gsmgogo.global.feign;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.springframework.http.HttpStatus;
+import team.gsmgogo.global.exception.error.ExpectedException;
+
+public class FeignClientErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) throws FeignException {
+
+        if(response.status() >= 400) {
+            throw new ExpectedException("Feign Client 예외가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        return FeignException.errorStatus(methodKey, response);
+    }
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthClient.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthClient.java
@@ -1,11 +1,14 @@
 package team.gsmgogo.global.feign;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import team.gsmgogo.global.config.GauthFeignConfig;
 import team.gsmgogo.global.feign.dto.GauthTokenDto;
 import team.gsmgogo.global.feign.dto.GauthTokenRequest;
+import team.gsmgogo.global.feign.dto.GauthUserDto;
 
 import java.net.URI;
 
@@ -14,5 +17,8 @@ public interface GauthClient {
 
     @PostMapping
     GauthTokenDto getToken(URI baseUrl, @RequestBody GauthTokenRequest gauthTokenRequest);
+
+    @GetMapping
+    GauthUserDto getInfo(URI baseUrl, @RequestHeader("Authorization") String accessToken);
 
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthClient.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthClient.java
@@ -2,9 +2,10 @@ package team.gsmgogo.global.feign;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
 import team.gsmgogo.global.config.GauthFeignConfig;
 import team.gsmgogo.global.feign.dto.GauthTokenDto;
+import team.gsmgogo.global.feign.dto.GauthTokenRequest;
 
 import java.net.URI;
 
@@ -12,9 +13,6 @@ import java.net.URI;
 public interface GauthClient {
 
     @PostMapping
-    GauthTokenDto getToken(URI baseUrl, @RequestParam("clientId") String clientId,
-                           @RequestParam("redirectUri") String redirectUrl,
-                           @RequestParam("code") String code,
-                           @RequestParam("clientSecret") String clientSecret);
+    GauthTokenDto getToken(URI baseUrl, @RequestBody GauthTokenRequest gauthTokenRequest);
 
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthClient.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthClient.java
@@ -1,0 +1,20 @@
+package team.gsmgogo.global.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import team.gsmgogo.global.config.GauthFeignConfig;
+import team.gsmgogo.global.feign.dto.GauthTokenDto;
+
+import java.net.URI;
+
+@FeignClient(name = "GauthClient", configuration = GauthFeignConfig.class)
+public interface GauthClient {
+
+    @PostMapping
+    GauthTokenDto getToken(URI baseUrl, @RequestParam("clientId") String clientId,
+                           @RequestParam("redirectUri") String redirectUrl,
+                           @RequestParam("code") String code,
+                           @RequestParam("clientSecret") String clientSecret);
+
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthInfo.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthInfo.java
@@ -1,0 +1,15 @@
+package team.gsmgogo.global.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import team.gsmgogo.global.config.GauthFeignConfig;
+import team.gsmgogo.global.feign.dto.GauthUserDto;
+
+import java.net.URI;
+
+@FeignClient(name = "GauthInfo", configuration = GauthFeignConfig.class, url = "https://open.gauth.co.kr/user")
+public interface GauthInfo {
+    @GetMapping
+    GauthUserDto getInfo(@RequestHeader("Authorization") String accessToken);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthInfo.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthInfo.java
@@ -6,8 +6,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import team.gsmgogo.global.config.GauthFeignConfig;
 import team.gsmgogo.global.feign.dto.GauthUserDto;
 
-import java.net.URI;
-
 @FeignClient(name = "GauthInfo", configuration = GauthFeignConfig.class, url = "https://open.gauth.co.kr/user")
 public interface GauthInfo {
     @GetMapping

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthToken.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthToken.java
@@ -1,16 +1,11 @@
 package team.gsmgogo.global.feign;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import team.gsmgogo.global.config.GauthFeignConfig;
 import team.gsmgogo.global.feign.dto.GauthTokenDto;
 import team.gsmgogo.global.feign.dto.GauthTokenRequest;
-import team.gsmgogo.global.feign.dto.GauthUserDto;
-
-import java.net.URI;
 
 @FeignClient(name = "GauthToken", configuration = GauthFeignConfig.class, url = "https://server.gauth.co.kr/oauth/token")
 public interface GauthToken {

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthToken.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/GauthToken.java
@@ -12,13 +12,8 @@ import team.gsmgogo.global.feign.dto.GauthUserDto;
 
 import java.net.URI;
 
-@FeignClient(name = "GauthClient", configuration = GauthFeignConfig.class)
-public interface GauthClient {
-
+@FeignClient(name = "GauthToken", configuration = GauthFeignConfig.class, url = "https://server.gauth.co.kr/oauth/token")
+public interface GauthToken {
     @PostMapping
-    GauthTokenDto getToken(URI baseUrl, @RequestBody GauthTokenRequest gauthTokenRequest);
-
-    @GetMapping
-    GauthUserDto getInfo(URI baseUrl, @RequestHeader("Authorization") String accessToken);
-
+    GauthTokenDto getToken(@RequestBody GauthTokenRequest gauthTokenRequest);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenDto.java
@@ -1,0 +1,11 @@
+package team.gsmgogo.global.feign.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GauthTokenDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenDto.java
@@ -1,10 +1,13 @@
 package team.gsmgogo.global.feign.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class GauthTokenDto {
     private String accessToken;
+    private String refreshToken;
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenDto.java
@@ -7,5 +7,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GauthTokenDto {
     private String accessToken;
-    private String refreshToken;
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenRequest.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthTokenRequest.java
@@ -1,0 +1,17 @@
+package team.gsmgogo.global.feign.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GauthTokenRequest {
+    private String code;
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
@@ -1,0 +1,16 @@
+package team.gsmgogo.global.feign.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Getter
+@NoArgsConstructor
+public class GauthUserDto {
+    private String email;
+    private String name;
+    private Integer grade;
+    private Integer classNum;
+    private UserSchoolRole role;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
@@ -1,5 +1,7 @@
 package team.gsmgogo.global.feign.dto;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +14,6 @@ public class GauthUserDto {
     private String name;
     private Integer grade;
     private Integer classNum;
+    @Enumerated(EnumType.STRING)
     private UserSchoolRole role;
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
@@ -2,10 +2,8 @@ package team.gsmgogo.global.feign.dto;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 
 @Getter
 @NoArgsConstructor

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/UserSchoolRole.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/UserSchoolRole.java
@@ -1,0 +1,14 @@
+package team.gsmgogo.global.feign.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserSchoolRole {
+
+    STUDENT("ROLE_STUDENT"),
+    TEACHER("ROLE_TEACHER");
+
+    private final String role;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/UserSchoolRole.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/UserSchoolRole.java
@@ -8,8 +8,7 @@ import lombok.Getter;
 public enum UserSchoolRole {
 
     ROLE_STUDENT("ROLE_STUDENT"),
-    ROLE_TEACHER("ROLE_TEACHER"),
-    ROLE_GRADUATE("ROLE_GRADUATE");
+    ROLE_TEACHER("ROLE_TEACHER");
 
     private final String role;
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/UserSchoolRole.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/UserSchoolRole.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserSchoolRole {
 
-    STUDENT("ROLE_STUDENT"),
-    TEACHER("ROLE_TEACHER");
+    ROLE_STUDENT("ROLE_STUDENT"),
+    ROLE_TEACHER("ROLE_TEACHER"),
+    ROLE_GRADUATE("ROLE_GRADUATE");
 
     private final String role;
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/security/jwt/JwtTokenProvider.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/security/jwt/JwtTokenProvider.java
@@ -36,25 +36,25 @@ public class JwtTokenProvider {
     public static final String ACCESS_KEY = "accessToken";
     public static final String REFRESH_KEY = "refreshToken";
 
-    public TokenResponse getToken(Long userSeq) {
-        String accessToken = generateAccessToken(userSeq, accessExp);
-        String refreshToken = generateRefrshToken(userSeq, refreshExp);
+    public TokenResponse getToken(Long userId) {
+        String accessToken = generateAccessToken(userId, accessExp);
+        String refreshToken = generateRefrshToken(userId, refreshExp);
 
         return new TokenResponse(accessToken, refreshToken);
     }
 
-    private String generateAccessToken(Long userSeq, long expiration) {
+    private String generateAccessToken(Long userId, long expiration) {
         return Jwts.builder().signWith(SignatureAlgorithm.HS256, secretKey)
-                .setSubject(String.valueOf(userSeq))
+                .setSubject(String.valueOf(userId))
                 .setHeaderParam("typ", ACCESS_KEY)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expiration * 1000))
                 .compact();
     }
 
-    private String generateRefrshToken(Long userSeq, long expiration) {
+    private String generateRefrshToken(Long userId, long expiration) {
         return Jwts.builder().signWith(SignatureAlgorithm.HS256, refreshKey)
-                .setSubject(String.valueOf(userSeq))
+                .setSubject(String.valueOf(userId))
                 .setHeaderParam("typ", REFRESH_KEY)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expiration * 1000))
@@ -69,7 +69,7 @@ public class JwtTokenProvider {
         return cookieManager.getCookieValue(request, REFRESH_KEY);
     }
 
-    public String getRefreshTokenUserSeq(String token){
+    public String getRefreshTokenUserId(String token){
         return getTokenBody(token).get("sub", String.class);
     }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/security/jwt/JwtTokenProvider.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/security/jwt/JwtTokenProvider.java
@@ -36,25 +36,25 @@ public class JwtTokenProvider {
     public static final String ACCESS_KEY = "accessToken";
     public static final String REFRESH_KEY = "refreshToken";
 
-    public TokenResponse getToken(String userSeq) {
+    public TokenResponse getToken(Long userSeq) {
         String accessToken = generateAccessToken(userSeq, accessExp);
         String refreshToken = generateRefrshToken(userSeq, refreshExp);
 
         return new TokenResponse(accessToken, refreshToken);
     }
 
-    private String generateAccessToken(String userSeq, long expiration) {
+    private String generateAccessToken(Long userSeq, long expiration) {
         return Jwts.builder().signWith(SignatureAlgorithm.HS256, secretKey)
-                .setSubject(userSeq)
+                .setSubject(String.valueOf(userSeq))
                 .setHeaderParam("typ", ACCESS_KEY)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expiration * 1000))
                 .compact();
     }
 
-    private String generateRefrshToken(String userSeq, long expiration) {
+    private String generateRefrshToken(Long userSeq, long expiration) {
         return Jwts.builder().signWith(SignatureAlgorithm.HS256, refreshKey)
-                .setSubject(userSeq)
+                .setSubject(String.valueOf(userSeq))
                 .setHeaderParam("typ", REFRESH_KEY)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expiration * 1000))
@@ -67,6 +67,10 @@ public class JwtTokenProvider {
 
     public String resolveRefreshToken(HttpServletRequest request) {
         return cookieManager.getCookieValue(request, REFRESH_KEY);
+    }
+
+    public String getRefreshTokenUserSeq(String token){
+        return getTokenBody(token).get("sub", String.class);
     }
 
     public UsernamePasswordAuthenticationToken authorization(String token) {

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/security/jwt/JwtTokenProvider.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/security/jwt/JwtTokenProvider.java
@@ -33,8 +33,8 @@ public class JwtTokenProvider {
     @Value("${spring.jwt.refreshExp}")
     public Long refreshExp;
 
-    private static final String ACCESS_KEY = "access_token";
-    private static final String REFRESH_KEY = "refresh_token";
+    public static final String ACCESS_KEY = "accessToken";
+    public static final String REFRESH_KEY = "refreshToken";
 
     public TokenResponse getToken(String userSeq) {
         String accessToken = generateAccessToken(userSeq, accessExp);

--- a/gsmgogo-api/src/main/resources/application.yml
+++ b/gsmgogo-api/src/main/resources/application.yml
@@ -17,13 +17,17 @@ spring:
         use_sql_comments: true
     database-platform: org.hibernate.dialect.H2Dialect
 
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-
   jwt:
     secretKey: ${SECRETKEY}
     refreshKey: ${REFRESHKEY}
     accessExp: ${ACCESSEXP}
     refreshExp: ${REFRESHEXP}
+
+gauth:
+  clientId: ${CLIENTID}
+  clientSecret: ${CLIENTSECRET}
+  redirectUrl: ${REDIRECTURL}
+  authUrl: ${AUTHURL}
+  userApiUrl: ${USERAPIURL}
 
 cookie-domain: localhost

--- a/gsmgogo-api/src/main/resources/application.yml
+++ b/gsmgogo-api/src/main/resources/application.yml
@@ -23,6 +23,11 @@ spring:
     accessExp: ${ACCESSEXP}
     refreshExp: ${REFRESHEXP}
 
+  data:
+    redis:
+      host: ${HOST}
+      port: ${PORT}
+
 gauth:
   clientId: ${CLIENTID}
   clientSecret: ${CLIENTSECRET}

--- a/gsmgogo-entity/build.gradle
+++ b/gsmgogo-entity/build.gradle
@@ -6,6 +6,10 @@ dependencies {
 	/* Spring Data Jpa */
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	/* redis */
+	implementation("org.springframework.session:spring-session-data-redis")
+	implementation 'io.lettuce:lettuce-core:6.2.3.RELEASE'
+
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/auth/entity/RefreshTokenRedisEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/auth/entity/RefreshTokenRedisEntity.java
@@ -14,8 +14,8 @@ import org.springframework.data.redis.core.index.Indexed;
 @Builder
 public class RefreshTokenRedisEntity {
     @Id
-    @Column(name = "user_email")
-    private String userEmail;
+    @Column(name = "user_seq")
+    private Long userSeq;
 
     @Indexed
     @Column(name = "refresh_token")
@@ -24,4 +24,9 @@ public class RefreshTokenRedisEntity {
     @TimeToLive
     @Column(name = "expired_at")
     private Long expiredAt;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/auth/entity/RefreshTokenRedisEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/auth/entity/RefreshTokenRedisEntity.java
@@ -14,8 +14,8 @@ import org.springframework.data.redis.core.index.Indexed;
 @Builder
 public class RefreshTokenRedisEntity {
     @Id
-    @Column(name = "user_seq")
-    private Long userSeq;
+    @Column(name = "user_id")
+    private Long userId;
 
     @Indexed
     @Column(name = "refresh_token")

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/auth/entity/RefreshTokenRedisEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/auth/entity/RefreshTokenRedisEntity.java
@@ -1,0 +1,27 @@
+package team.gsmgogo.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash("refreshToken")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshTokenRedisEntity {
+    @Id
+    @Column(name = "user_email")
+    private String userEmail;
+
+    @Indexed
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    @TimeToLive
+    @Column(name = "expired_at")
+    private Long expiredAt;
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/entity/UserEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/entity/UserEntity.java
@@ -18,8 +18,8 @@ public class UserEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_seq")
-    private Long userSeq;
+    @Column(name = "user_id")
+    private Long userId;
 
     @Column(name = "user_name")
     private String userName;


### PR DESCRIPTION
## 개요

Auth 부분 api를 작성하였습니다.

## 작업내용

Gauth를 사용하여 oauth 로그인 방식을 구현하였습니다.

- `/auth/login`: 로그인 페이지로 리다이렉트 됩니다.

- `/auth/callback?code=`: 로그인 후 프론트엔드로 리다이렉트된 uri 쿼리에 있는 code를 서버로 보냅니다. 해당 code로 서버에서 로그인, 회원가입 처리를 진행합니다.

- `/auth/refresh`: 쿠키에 있는 `refreshToken`으로 새로운 `accessToken`, `refreshToken`을 발급합니다.