### PR TITLE
배드민턴 팀 등록, 응원하는 팀 등록 API 작성

### DIFF
--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/auth/service/impl/GauthLoginServiceImpl.java
@@ -54,6 +54,7 @@ public class GauthLoginServiceImpl implements GauthLoginService {
 
         GauthUserDto gauthUserDto = gauthInfo.getInfo("Bearer " + gauthTokenDto.getAccessToken());
 
+        Gender gender = gauthUserDto.getGender();
         Integer grade = gauthUserDto.getGrade();
         Integer classNum = gauthUserDto.getClassNum();
         Integer userNum = gauthUserDto.getNum();
@@ -98,6 +99,7 @@ public class GauthLoginServiceImpl implements GauthLoginService {
                     .role(Role.USER)
                     .verifyCount(0L)
                     .userNum(userNum)
+                    .gender(gender)
                     .point(30000).build();
 
             userId = userJpaRepository.save(newUser).getUserId();

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/TeamController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/TeamController.java
@@ -5,9 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
 import team.gsmgogo.domain.team.controller.dto.request.TeamDeleteRequest;
 import team.gsmgogo.domain.team.controller.dto.request.TeamNormalSaveRequest;
 import team.gsmgogo.domain.team.controller.dto.request.TeamSaveRequest;
+import team.gsmgogo.domain.team.service.TeamBadmintonSaveService;
 import team.gsmgogo.domain.team.service.TeamDeleteService;
 import team.gsmgogo.domain.team.service.TeamNormalSaveService;
 import team.gsmgogo.domain.team.service.TeamSaveService;
@@ -22,6 +24,7 @@ public class TeamController {
     private final TeamSaveService teamSaveService;
     private final TeamNormalSaveService teamNormalSaveService;
     private final TeamDeleteService teamDeleteService;
+    private final TeamBadmintonSaveService teamBadmintonSaveService;
 
     @PostMapping
     public ResponseEntity<Void> saveTeam(@RequestBody @Valid TeamSaveRequest request) {
@@ -39,6 +42,12 @@ public class TeamController {
     public ResponseEntity<Void> deleteTeam(@RequestBody @Valid TeamDeleteRequest request) {
         teamDeleteService.deleteTeam(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/badminton")
+    public ResponseEntity<Void> saveTeamBadminton(@RequestBody @Valid TeamBadmintonSaveRequest request) {
+        teamBadmintonSaveService.saveBadmintonTeam(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/TeamController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/TeamController.java
@@ -5,14 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
-import team.gsmgogo.domain.team.controller.dto.request.TeamDeleteRequest;
-import team.gsmgogo.domain.team.controller.dto.request.TeamNormalSaveRequest;
-import team.gsmgogo.domain.team.controller.dto.request.TeamSaveRequest;
-import team.gsmgogo.domain.team.service.TeamBadmintonSaveService;
-import team.gsmgogo.domain.team.service.TeamDeleteService;
-import team.gsmgogo.domain.team.service.TeamNormalSaveService;
-import team.gsmgogo.domain.team.service.TeamSaveService;
+import team.gsmgogo.domain.team.controller.dto.request.*;
+import team.gsmgogo.domain.team.service.*;
 
 import java.util.List;
 
@@ -25,6 +19,7 @@ public class TeamController {
     private final TeamNormalSaveService teamNormalSaveService;
     private final TeamDeleteService teamDeleteService;
     private final TeamBadmintonSaveService teamBadmintonSaveService;
+    private final TeamFollowService teamFollowService;
 
     @PostMapping
     public ResponseEntity<Void> saveTeam(@RequestBody @Valid TeamSaveRequest request) {
@@ -48,6 +43,12 @@ public class TeamController {
     public ResponseEntity<Void> saveTeamBadminton(@RequestBody @Valid TeamBadmintonSaveRequest request) {
         teamBadmintonSaveService.saveBadmintonTeam(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/follow")
+    public ResponseEntity<Void> followTeam(@RequestBody @Valid TeamFollowRequest request) {
+        teamFollowService.followTeam(request);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamBadmintonSaveRequest.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamBadmintonSaveRequest.java
@@ -1,0 +1,25 @@
+package team.gsmgogo.domain.team.controller.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.gsmgogo.domain.team.enums.TeamType;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TeamBadmintonSaveRequest {
+    @NotBlank
+    @Size(min = 1, max = 5)
+    @Pattern(regexp = "\\S{1,5}")
+    private String teamName;
+    @NotNull
+    private List<TeamParticipateDto> participates;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamBadmintonSaveRequest.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamBadmintonSaveRequest.java
@@ -8,7 +8,6 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.gsmgogo.domain.team.enums.TeamType;
 
 import java.util.List;
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamFollowRequest.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamFollowRequest.java
@@ -1,0 +1,15 @@
+package team.gsmgogo.domain.team.controller.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class TeamFollowRequest {
+    @NotNull
+    private Long teamId;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/TeamBadmintonSaveService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/TeamBadmintonSaveService.java
@@ -1,0 +1,7 @@
+package team.gsmgogo.domain.team.service;
+
+import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
+
+public interface TeamBadmintonSaveService {
+    void saveBadmintonTeam(TeamBadmintonSaveRequest request);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/TeamFollowService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/TeamFollowService.java
@@ -1,7 +1,7 @@
 package team.gsmgogo.domain.team.service;
 
-import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
+import team.gsmgogo.domain.team.controller.dto.request.TeamFollowRequest;
 
 public interface TeamFollowService {
-    void followTeam(TeamBadmintonSaveRequest request);
+    void followTeam(TeamFollowRequest request);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/TeamFollowService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/TeamFollowService.java
@@ -1,0 +1,7 @@
+package team.gsmgogo.domain.team.service;
+
+import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
+
+public interface TeamFollowService {
+    void followTeam(TeamBadmintonSaveRequest request);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
@@ -65,7 +65,7 @@ public class TeamBadmintonSaveServiceImpl implements TeamBadmintonSaveService {
         BadmintonRank rank = null;
 
         if (
-            participateA.getGender() == Gender.MALE && participateB.getGender() == Gender.MALE ||
+            participateA.getGender() == Gender.MALE && participateB.getGender() == Gender.MALE &&
             participateA.getUserGrade() == GradeEnum.ONE && participateB.getUserGrade() == GradeEnum.ONE
         ) {
             rank = BadmintonRank.C;
@@ -74,7 +74,7 @@ public class TeamBadmintonSaveServiceImpl implements TeamBadmintonSaveService {
         ) {
             rank = BadmintonRank.D;
         } else if (
-                participateA.getGender() == Gender.MALE && participateB.getGender() == Gender.MALE ||
+                participateA.getGender() == Gender.MALE && participateB.getGender() == Gender.MALE &&
                 (participateA.getUserGrade() == GradeEnum.TWO || participateA.getUserGrade() == GradeEnum.THREE)
                         &&
                 (participateB.getUserGrade() == GradeEnum.TWO || participateB.getUserGrade() == GradeEnum.THREE)

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
@@ -3,6 +3,7 @@ package team.gsmgogo.domain.team.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
 import team.gsmgogo.domain.team.entity.TeamEntity;
 import team.gsmgogo.domain.team.enums.BadmintonRank;
@@ -33,6 +34,7 @@ public class TeamBadmintonSaveServiceImpl implements TeamBadmintonSaveService {
     private final UserFacade userFacade;
 
     @Override
+    @Transactional
     public void saveBadmintonTeam(TeamBadmintonSaveRequest request) {
         UserEntity currentUser = userFacade.getCurrentUser();
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
@@ -1,0 +1,115 @@
+package team.gsmgogo.domain.team.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
+import team.gsmgogo.domain.team.entity.TeamEntity;
+import team.gsmgogo.domain.team.enums.BadmintonRank;
+import team.gsmgogo.domain.team.enums.TeamType;
+import team.gsmgogo.domain.team.repository.TeamJpaRepository;
+import team.gsmgogo.domain.team.service.TeamBadmintonSaveService;
+import team.gsmgogo.domain.teamparticipate.entity.TeamParticipateEntity;
+import team.gsmgogo.domain.teamparticipate.repository.TeamParticipateJpaRepository;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.enums.Gender;
+import team.gsmgogo.domain.user.enums.GradeEnum;
+import team.gsmgogo.domain.user.repository.UserJpaRepository;
+import team.gsmgogo.global.exception.error.ExpectedException;
+import team.gsmgogo.global.facade.UserFacade;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class TeamBadmintonSaveServiceImpl implements TeamBadmintonSaveService {
+
+    private final TeamJpaRepository teamJpaRepository;
+    private final TeamParticipateJpaRepository teamParticipateJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final UserFacade userFacade;
+
+    @Override
+    public void saveBadmintonTeam(TeamBadmintonSaveRequest request) {
+        UserEntity currentUser = userFacade.getCurrentUser();
+
+        if (request.getParticipates().size() != 2)
+            throw new ExpectedException("배드민턴 참가 가능 인원은 2명입니다.", HttpStatus.BAD_REQUEST);
+
+        if (request.getParticipates().stream().noneMatch(user -> user.getUserId().equals(currentUser.getUserId())))
+            throw new ExpectedException("참가 인원에 본인을 포함해주세요.", HttpStatus.BAD_REQUEST);
+
+        UserEntity participateA = userJpaRepository.findByUserId(request.getParticipates().get(0).getUserId())
+                .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        UserEntity participateB = userJpaRepository.findByUserId(request.getParticipates().get(1).getUserId())
+                .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (Objects.equals(participateA.getUserId(), participateB.getUserId()))
+            throw new ExpectedException("참가 인원이 중복되서는 안됩니다.", HttpStatus.BAD_REQUEST);
+
+        if (participateA.getGender() != participateB.getGender()) {
+            throw new ExpectedException("참가 인원의 성별은 같아야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        if (teamJpaRepository.existsByTeamGradeAndTeamClassAndTeamType
+                (participateA.getUserGrade(), participateA.getUserClass(), TeamType.BADMINTON)
+            ||
+                teamJpaRepository.existsByTeamGradeAndTeamClassAndTeamType
+                        (participateB.getUserGrade(), participateB.getUserClass(), TeamType.BADMINTON)
+        )
+            throw new ExpectedException("이미 등록된 팀이 있습니다.", HttpStatus.BAD_REQUEST);
+
+        BadmintonRank rank = null;
+
+        if (
+            participateA.getGender() == Gender.MALE && participateB.getGender() == Gender.MALE ||
+            participateA.getUserGrade() == GradeEnum.ONE && participateB.getUserGrade() == GradeEnum.ONE
+        ) {
+            rank = BadmintonRank.C;
+        } else if (
+                participateA.getGender() == Gender.FEMALE && participateB.getGender() == Gender.FEMALE
+        ) {
+            rank = BadmintonRank.D;
+        } else if (
+                participateA.getGender() == Gender.MALE && participateB.getGender() == Gender.MALE ||
+                (participateA.getUserGrade() == GradeEnum.TWO || participateA.getUserGrade() == GradeEnum.THREE)
+                        &&
+                (participateB.getUserGrade() == GradeEnum.TWO || participateB.getUserGrade() == GradeEnum.THREE)
+        ) {
+            rank = BadmintonRank.B;
+        }
+
+        TeamEntity newTeam = TeamEntity.builder()
+                .teamName(request.getTeamName())
+                .winCount(0)
+                .isSurvived(true)
+                .teamClass(currentUser.getUserClass())
+                .teamGrade(currentUser.getUserGrade())
+                .teamType(TeamType.BADMINTON)
+                .badmintonRank(rank)
+                .build();
+
+        TeamEntity savedTeam = teamJpaRepository.save(newTeam);
+
+        TeamParticipateEntity newParticipateA = TeamParticipateEntity.builder()
+                        .team(savedTeam)
+                        .user(participateA)
+                        .positionX(request.getParticipates().get(0).getPositionX())
+                        .positionY(request.getParticipates().get(0).getPositionY())
+                        .build();
+
+        TeamParticipateEntity newParticipateB = TeamParticipateEntity.builder()
+                .team(savedTeam)
+                .user(participateB)
+                .positionX(request.getParticipates().get(1).getPositionX())
+                .positionY(request.getParticipates().get(1).getPositionY())
+                .build();
+
+        teamParticipateJpaRepository.save(newParticipateA);
+        teamParticipateJpaRepository.save(newParticipateB);
+
+    }
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamDeleteServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamDeleteServiceImpl.java
@@ -3,6 +3,7 @@ package team.gsmgogo.domain.team.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.gsmgogo.domain.team.controller.dto.request.TeamDeleteRequest;
 import team.gsmgogo.domain.team.entity.TeamEntity;
 import team.gsmgogo.domain.team.repository.TeamJpaRepository;
@@ -19,6 +20,7 @@ public class TeamDeleteServiceImpl implements TeamDeleteService {
     private final UserFacade userFacade;
 
     @Override
+    @Transactional
     public void deleteTeam(TeamDeleteRequest request) {
         TeamEntity team = teamJpaRepository.findByTeamId(request.getTeamId())
                 .orElseThrow(() -> new ExpectedException("팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFollowServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFollowServiceImpl.java
@@ -1,0 +1,40 @@
+package team.gsmgogo.domain.team.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.gsmgogo.domain.follow.entity.FollowEntity;
+import team.gsmgogo.domain.follow.repository.FollowJpaRepository;
+import team.gsmgogo.domain.team.controller.dto.request.TeamBadmintonSaveRequest;
+import team.gsmgogo.domain.team.controller.dto.request.TeamFollowRequest;
+import team.gsmgogo.domain.team.repository.TeamJpaRepository;
+import team.gsmgogo.domain.team.service.TeamFollowService;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.global.exception.error.ExpectedException;
+import team.gsmgogo.global.facade.UserFacade;
+
+@Service
+@RequiredArgsConstructor
+public class TeamFollowServiceImpl implements TeamFollowService {
+
+    private final FollowJpaRepository followJpaRepository;
+    private final TeamJpaRepository teamJpaRepository;
+    private final UserFacade userFacade;
+
+    @Override
+    @Transactional
+    public void followTeam(TeamFollowRequest request) {
+        UserEntity currentUser = userFacade.getCurrentUser();
+
+        if (followJpaRepository.existsByUser(currentUser))
+            throw new ExpectedException("이미 팀을 팔로우 했습니다.", HttpStatus.BAD_REQUEST);
+
+        FollowEntity follow = FollowEntity.builder()
+                .team(teamJpaRepository.findByTeamId(request.getTeamId())
+                        .orElseThrow(() -> new ExpectedException("팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)))
+                .build();
+
+        followJpaRepository.save(follow);
+    }
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFollowServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFollowServiceImpl.java
@@ -33,6 +33,7 @@ public class TeamFollowServiceImpl implements TeamFollowService {
         FollowEntity follow = FollowEntity.builder()
                 .team(teamJpaRepository.findByTeamId(request.getTeamId())
                         .orElseThrow(() -> new ExpectedException("팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)))
+                .user(currentUser)
                 .build();
 
         followJpaRepository.save(follow);

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
@@ -3,6 +3,7 @@ package team.gsmgogo.domain.team.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.gsmgogo.domain.normalteamparticipate.entity.NormalTeamParticipateEntity;
 import team.gsmgogo.domain.normalteamparticipate.repository.NormalTeamParticipateJpaRepository;
 import team.gsmgogo.domain.team.controller.dto.request.TeamNormalSaveRequest;
@@ -31,6 +32,7 @@ public class TeamNormalSaveServiceImpl implements TeamNormalSaveService {
     private final UserFacade userFacade;
 
     @Override
+    @Transactional
     public void saveNormalTeam(List<TeamNormalSaveRequest> request) {
         UserEntity currentUser = userFacade.getCurrentUser();
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/feign/dto/GauthUserDto.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.gsmgogo.domain.user.enums.Gender;
 
 @Getter
 @NoArgsConstructor
@@ -12,6 +13,8 @@ public class GauthUserDto {
     private String name;
     private Integer grade;
     private Integer classNum;
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
     private Integer num;
     @Enumerated(EnumType.STRING)
     private UserSchoolRole role;

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/follow/repository/FollowJpaRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/follow/repository/FollowJpaRepository.java
@@ -2,6 +2,8 @@ package team.gsmgogo.domain.follow.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.gsmgogo.domain.follow.entity.FollowEntity;
+import team.gsmgogo.domain.user.entity.UserEntity;
 
 public interface FollowJpaRepository extends JpaRepository<FollowEntity, Long> {
+    boolean existsByUser(UserEntity user);
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/normalteamparticipate/enums/NormalTeamType.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/normalteamparticipate/enums/NormalTeamType.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum NormalTeamType {
-
-    TOSS_RUN("TOSS_RUN"), // 이어달리기
-    TUG_OF_WAR("TUG_OF_WAR"); // 줄다리기
-
-    private final String type;
+    TOSS_RUN, // 이어달리기
+    MISSION_RUN, // 미션달리기
+    TUG_OF_WAR, // 줄다리기
+    FREE_THROW, // 자유투 릴레이
+    GROUP_ROPE_JUMP // 단체 줄넘기
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/entity/TeamEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/entity/TeamEntity.java
@@ -3,6 +3,7 @@ package team.gsmgogo.domain.team.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import team.gsmgogo.domain.normalteamparticipate.entity.NormalTeamParticipateEntity;
+import team.gsmgogo.domain.team.enums.BadmintonRank;
 import team.gsmgogo.domain.team.enums.TeamType;
 import team.gsmgogo.domain.teamparticipate.entity.TeamParticipateEntity;
 import team.gsmgogo.domain.user.enums.ClassEnum;
@@ -44,6 +45,10 @@ public class TeamEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "team_class")
     private ClassEnum teamClass;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "badminton_rank")
+    private BadmintonRank badmintonRank;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TeamParticipateEntity> teamParticipates = new ArrayList<>();

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/enums/BadmintonRank.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/enums/BadmintonRank.java
@@ -1,0 +1,13 @@
+package team.gsmgogo.domain.team.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BadmintonRank {
+    A,
+    B,
+    C,
+    D; // 여자조
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/enums/TeamType.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/enums/TeamType.java
@@ -7,10 +7,9 @@ import lombok.Getter;
 @Getter
 public enum TeamType {
 
-    SOCCER("SOCCER"),
-    BASKETBALL("BASKETBALL"),
-    VOLLEYBALL("VOLLEYBALL"),
-    NORMAL("NORMAL"); // 일반경기
+    SOCCER,
+    BADMINTON,
+    VOLLEYBALL,
+    NORMAL; // 일반경기
 
-    private final String type;
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/entity/UserEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/entity/UserEntity.java
@@ -40,6 +40,10 @@ public class UserEntity {
     @Column(name = "user_num")
     private Integer userNum;
 
+    @Column(name = "user_gender")
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
     @Column(name = "school_role")
     @Enumerated(EnumType.STRING)
     private SchoolRole schoolRole;

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/enums/Gender.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/enums/Gender.java
@@ -1,0 +1,11 @@
+package team.gsmgogo.domain.user.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Gender {
+    MALE,
+    FEMALE
+}


### PR DESCRIPTION
## 개요

배드민턴 팀 등록, 응원하는 팀 등록 API를 작성하였습니다.

## 작업내용

배드민턴 팀 등록 `/team/badminton`

- 팀에 `badminton_rank` 컬럼을 추가하여 배드민턴 랭크를 부여하였습니다.

응원하는 팀 등록 `/team/follow`

- 팀 `id`를 통해 팀을 응원할 수 있고 한 팀만 응원이 가능합니다.
---

<img width="344" alt="스크린샷 2024-03-27 오후 6 23 11" src="https://github.com/GSM-GOGO/GSM-GOGO-Server/assets/131235625/37e8e18c-cdfb-4676-bcf4-98d5f120b917">

해당 조건절을 통해 팀의 배드민턴 랭크를 부여하였습니다.