### PR TITLE
유저 정보 검색 및 팀 등록 Validation 추가

### DIFF
--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
@@ -7,11 +7,13 @@ import org.springframework.transaction.annotation.Transactional;
 import team.gsmgogo.domain.normalteamparticipate.entity.NormalTeamParticipateEntity;
 import team.gsmgogo.domain.normalteamparticipate.repository.NormalTeamParticipateJpaRepository;
 import team.gsmgogo.domain.team.controller.dto.request.TeamNormalSaveRequest;
+import team.gsmgogo.domain.team.controller.dto.response.TeamClassType;
 import team.gsmgogo.domain.team.entity.TeamEntity;
 import team.gsmgogo.domain.team.enums.TeamType;
 import team.gsmgogo.domain.team.repository.TeamJpaRepository;
 import team.gsmgogo.domain.team.service.TeamNormalSaveService;
 import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.enums.ClassEnum;
 import team.gsmgogo.domain.user.repository.UserJpaRepository;
 import team.gsmgogo.global.exception.error.ExpectedException;
 import team.gsmgogo.global.facade.UserFacade;
@@ -44,16 +46,18 @@ public class TeamNormalSaveServiceImpl implements TeamNormalSaveService {
             UserEntity findUser = userJpaRepository.findByUserId(user.getUserId())
                     .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
-//            if (
-//                    findUser.getUserGrade() != currentUser.getUserGrade() ||
-//                    findUser.getUserClass()
-//            )
+            if (
+                    findUser.getUserGrade() != currentUser.getUserGrade() ||
+                    toTeamClassType(findUser.getUserClass()) != toTeamClassType(currentUser.getUserClass())
+            ) {
+                throw new ExpectedException("참가 인원이 같은 학년, 과의 학생 확인해주세요.", HttpStatus.BAD_REQUEST);
+            }
 
-        })
+            return findUser;
+        }).toList();
 
         Set<Long> chackDublicate = new HashSet<>();
-
-        request.forEach(
+        participates.forEach(
                 participate -> {
                     if (!chackDublicate.add(participate.getUserId())) {
                         throw new ExpectedException("참가 인원이 중복되서는 안됩니다.", HttpStatus.BAD_REQUEST);
@@ -79,5 +83,13 @@ public class TeamNormalSaveServiceImpl implements TeamNormalSaveService {
 
         normalTeamParticipateJpaRepository.saveAll(normalTeamParticipateEntities);
     }
+
+    private TeamClassType toTeamClassType(ClassEnum classEnum) {
+        if (classEnum == ClassEnum.ONE || classEnum == ClassEnum.TWO)
+            return TeamClassType.SW;
+        else
+            return TeamClassType.EB;
+    }
+
 }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
@@ -42,7 +42,16 @@ public class TeamNormalSaveServiceImpl implements TeamNormalSaveService {
                 (currentUser.getUserGrade(), currentUser.getUserClass(), TeamType.NORMAL))
             throw new ExpectedException("이미 등록된 팀이 있습니다.", HttpStatus.BAD_REQUEST);
 
-        List<UserEntity> participates = request.stream().map(user -> {
+        Set<Long> chackDublicate = new HashSet<>();
+        request.forEach(
+                participate -> {
+                    if (!chackDublicate.add(participate.getUserId())) {
+                        throw new ExpectedException("참가 인원이 중복되서는 안됩니다.", HttpStatus.BAD_REQUEST);
+                    }
+                }
+        );
+
+        request.stream().map(user -> {
             UserEntity findUser = userJpaRepository.findByUserId(user.getUserId())
                     .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
@@ -56,14 +65,6 @@ public class TeamNormalSaveServiceImpl implements TeamNormalSaveService {
             return findUser;
         }).toList();
 
-        Set<Long> chackDublicate = new HashSet<>();
-        participates.forEach(
-                participate -> {
-                    if (!chackDublicate.add(participate.getUserId())) {
-                        throw new ExpectedException("참가 인원이 중복되서는 안됩니다.", HttpStatus.BAD_REQUEST);
-                    }
-                }
-        );
 
         TeamEntity newTeam = TeamEntity.builder()
                 .teamClass(currentUser.getUserClass())

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamNormalSaveServiceImpl.java
@@ -40,6 +40,17 @@ public class TeamNormalSaveServiceImpl implements TeamNormalSaveService {
                 (currentUser.getUserGrade(), currentUser.getUserClass(), TeamType.NORMAL))
             throw new ExpectedException("이미 등록된 팀이 있습니다.", HttpStatus.BAD_REQUEST);
 
+        List<UserEntity> participates = request.stream().map(user -> {
+            UserEntity findUser = userJpaRepository.findByUserId(user.getUserId())
+                    .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+//            if (
+//                    findUser.getUserGrade() != currentUser.getUserGrade() ||
+//                    findUser.getUserClass()
+//            )
+
+        })
+
         Set<Long> chackDublicate = new HashSet<>();
 
         request.forEach(

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamSaveServiceImpl.java
@@ -5,12 +5,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.gsmgogo.domain.team.controller.dto.request.TeamSaveRequest;
+import team.gsmgogo.domain.team.controller.dto.response.TeamClassType;
 import team.gsmgogo.domain.team.entity.TeamEntity;
 import team.gsmgogo.domain.team.repository.TeamJpaRepository;
 import team.gsmgogo.domain.team.service.TeamSaveService;
 import team.gsmgogo.domain.teamparticipate.entity.TeamParticipateEntity;
 import team.gsmgogo.domain.teamparticipate.repository.TeamParticipateJpaRepository;
 import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.enums.ClassEnum;
 import team.gsmgogo.domain.user.repository.UserJpaRepository;
 import team.gsmgogo.global.exception.error.ExpectedException;
 import team.gsmgogo.global.facade.UserFacade;
@@ -48,6 +50,20 @@ public class TeamSaveServiceImpl implements TeamSaveService {
                 }
         );
 
+        request.getParticipates().stream().map(user -> {
+            UserEntity findUser = userJpaRepository.findByUserId(user.getUserId())
+                    .orElseThrow(() -> new ExpectedException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+            if (
+                    findUser.getUserGrade() != currentUser.getUserGrade() ||
+                            toTeamClassType(findUser.getUserClass()) != toTeamClassType(currentUser.getUserClass())
+            ) {
+                throw new ExpectedException("참가 인원이 같은 학년, 과의 학생 확인해주세요.", HttpStatus.BAD_REQUEST);
+            }
+
+            return findUser;
+        }).toList();
+
         TeamEntity newTeam = TeamEntity.builder()
                 .teamName(request.getTeamName())
                 .winCount(0)
@@ -72,4 +88,12 @@ public class TeamSaveServiceImpl implements TeamSaveService {
         teamParticipateJpaRepository.saveAll(participates);
 
     }
+
+    private TeamClassType toTeamClassType(ClassEnum classEnum) {
+        if (classEnum == ClassEnum.ONE || classEnum == ClassEnum.TWO)
+            return TeamClassType.SW;
+        else
+            return TeamClassType.EB;
+    }
+
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/controller/UserController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/controller/UserController.java
@@ -1,0 +1,26 @@
+package team.gsmgogo.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.gsmgogo.domain.user.dto.response.UserInfoResponse;
+import team.gsmgogo.domain.user.service.QueryUserInfoService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserController {
+
+    private final QueryUserInfoService queryUserInfoService;
+
+    @GetMapping
+    public ResponseEntity<List<UserInfoResponse>> queryUser(@RequestParam String name) {
+        return ResponseEntity.ok(queryUserInfoService.queryUserInfo(name));
+    }
+
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/controller/UserController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/controller/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
     private final QueryUserInfoService queryUserInfoService;
 
     @GetMapping
-    public ResponseEntity<List<UserInfoResponse>> queryUser(@RequestParam String name) {
+    public ResponseEntity<List<UserInfoResponse>> queryUser(@RequestParam(name = "name") String name) {
         return ResponseEntity.ok(queryUserInfoService.queryUserInfo(name));
     }
 

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/dto/response/UserInfoResponse.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,26 @@
+package team.gsmgogo.domain.user.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.gsmgogo.domain.user.enums.ClassEnum;
+import team.gsmgogo.domain.user.enums.GradeEnum;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class UserInfoResponse {
+    private Long userId;
+    private String userName;
+    @Enumerated(EnumType.STRING)
+    private GradeEnum userGrade;
+    @Enumerated(EnumType.STRING)
+    private ClassEnum userClass;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/QueryUserInfoService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/QueryUserInfoService.java
@@ -2,6 +2,8 @@ package team.gsmgogo.domain.user.service;
 
 import team.gsmgogo.domain.user.dto.response.UserInfoResponse;
 
+import java.util.List;
+
 public interface QueryUserInfoService {
-    UserInfoResponse queryUserInfo(String name);
+    List<UserInfoResponse> queryUserInfo(String name);
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/QueryUserInfoService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/QueryUserInfoService.java
@@ -1,0 +1,7 @@
+package team.gsmgogo.domain.user.service;
+
+import team.gsmgogo.domain.user.dto.response.UserInfoResponse;
+
+public interface QueryUserInfoService {
+    UserInfoResponse queryUserInfo(String name);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/impl/QueryUserInfoServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/impl/QueryUserInfoServiceImpl.java
@@ -1,0 +1,34 @@
+package team.gsmgogo.domain.user.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.gsmgogo.domain.user.dto.response.UserInfoResponse;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.repository.UserJpaRepository;
+import team.gsmgogo.domain.user.service.QueryUserInfoService;
+import team.gsmgogo.global.facade.UserFacade;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QueryUserInfoServiceImpl implements QueryUserInfoService {
+
+    private final UserJpaRepository userJpaRepository;
+    private final UserFacade userFacade;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<UserInfoResponse> queryUserInfo(String name) {
+        UserEntity currentUser = userFacade.getCurrentUser();
+
+        return userJpaRepository.findUserNameAndUserGradeByLimited(name, currentUser.getUserGrade(), 10)
+                .stream().map(user -> UserInfoResponse.builder()
+                        .userId(user.getUserId())
+                        .userName(user.getUserName())
+                        .userGrade(user.getUserGrade())
+                        .userClass(user.getUserClass())
+                        .build()).toList();
+    }
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/impl/QueryUserInfoServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/user/service/impl/QueryUserInfoServiceImpl.java
@@ -23,7 +23,7 @@ public class QueryUserInfoServiceImpl implements QueryUserInfoService {
     public List<UserInfoResponse> queryUserInfo(String name) {
         UserEntity currentUser = userFacade.getCurrentUser();
 
-        return userJpaRepository.findUserNameAndUserGradeByLimited(name, currentUser.getUserGrade(), 10)
+        return userJpaRepository.findTop5ByUserNameContainingAndUserGradeOrderByUserNameAsc(name, currentUser.getUserGrade())
                 .stream().map(user -> UserInfoResponse.builder()
                         .userId(user.getUserId())
                         .userName(user.getUserName())

--- a/gsmgogo-api/src/main/resources/application.yml
+++ b/gsmgogo-api/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+        show_sql: true
     database-platform: org.hibernate.dialect.MySQLDialect
 
   jwt:

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
@@ -1,12 +1,20 @@
 package team.gsmgogo.domain.user.repository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.gsmgogo.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.gsmgogo.domain.user.enums.GradeEnum;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUserEmail(String userEmail);
     Optional<UserEntity> findByUserId(Long userId);
+
+
+    @Query("SELECT u FROM UserEntity u WHERE u.userName = :name AND u.userGrade = :grade")
+    List<UserEntity> findUserNameAndUserGradeByLimited(@Param("name") String name, @Param("grade") GradeEnum grade, int limit);
 
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/repository/UserJpaRepository.java
@@ -13,8 +13,5 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUserEmail(String userEmail);
     Optional<UserEntity> findByUserId(Long userId);
 
-
-    @Query("SELECT u FROM UserEntity u WHERE u.userName = :name AND u.userGrade = :grade")
-    List<UserEntity> findUserNameAndUserGradeByLimited(@Param("name") String name, @Param("grade") GradeEnum grade, int limit);
-
+    List<UserEntity> findTop5ByUserNameContainingAndUserGradeOrderByUserNameAsc(String userName, GradeEnum userGrade);
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/repository/dto/UserInfoQueryDto.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/user/repository/dto/UserInfoQueryDto.java
@@ -1,0 +1,19 @@
+package team.gsmgogo.domain.user.repository.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.gsmgogo.domain.user.enums.ClassEnum;
+import team.gsmgogo.domain.user.enums.GradeEnum;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoQueryDto {
+    private Long userId;
+    private String userName;
+    private GradeEnum userGrade;
+    private ClassEnum userClass;
+}


### PR DESCRIPTION
- 유저 이름으로 유저를 검색하면 **검색하는 유저와 같은 학년의 유저**가 반환됩니다.
- 최대 5개의 검색 결과가 반환됩니다.

- 일반팀, 메인팀 등록시 같은 학년, 같은 과의 유저만 등록되도록 Validation를 추가하였습니다.