### PR TITLE
팀 이름 최대 글자수 6글자 제한

### DIFF
--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamBadmintonSaveRequest.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamBadmintonSaveRequest.java
@@ -16,8 +16,8 @@ import java.util.List;
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TeamBadmintonSaveRequest {
     @NotBlank
-    @Size(min = 1, max = 5)
-    @Pattern(regexp = "\\S{1,5}")
+    @Size(min = 1, max = 6)
+    @Pattern(regexp = "\\S{1,6}")
     private String teamName;
     @NotNull
     private List<TeamParticipateDto> participates;

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamSaveRequest.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/controller/dto/request/TeamSaveRequest.java
@@ -14,8 +14,8 @@ import java.util.List;
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TeamSaveRequest {
     @NotBlank
-    @Size(min = 1, max = 7)
-    @Pattern(regexp = "\\S{1,7}")
+    @Size(min = 1, max = 6)
+    @Pattern(regexp = "\\S{1,6}")
     private String teamName;
     @NotNull
     private TeamType teamType;

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/entity/TeamEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/entity/TeamEntity.java
@@ -30,7 +30,7 @@ public class TeamEntity {
     @JoinColumn(name = "user_id")
     private UserEntity author;
 
-    @Column(name = "team_name", length = 7)
+    @Column(name = "team_name", length = 6)
     private String teamName;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
- 팀 등록시 팀 이름의 글자 수 제한을 6글자로 변경하였습니다.
- 팀 엔티티의 팀 이름 글자수를 6글자로 변경하였습니다.