### PR TITLE
배드민턴 팀 등록 중복 확인 Validation 수정

### DIFF
--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamBadmintonSaveServiceImpl.java
@@ -57,12 +57,11 @@ public class TeamBadmintonSaveServiceImpl implements TeamBadmintonSaveService {
             throw new ExpectedException("참가 인원의 성별은 같아야 합니다.", HttpStatus.BAD_REQUEST);
         }
 
-        if (teamJpaRepository.existsByAuthorAndTeamType
-                (participateA, TeamType.BADMINTON)
-            ||
-                teamJpaRepository.existsByAuthorAndTeamType
-                        (participateB, TeamType.BADMINTON)
-        )
+        if (teamJpaRepository.findByTeamType(TeamType.BADMINTON).stream()
+                .anyMatch(team ->
+                        team.getTeamParticipates().stream()
+                                .anyMatch(participate -> participate.getUser().getUserId().equals(participateA.getUserId()) ||
+                                        participate.getUser().getUserId().equals(participateB.getUserId()))))
             throw new ExpectedException("이미 등록된 팀이 있습니다.", HttpStatus.BAD_REQUEST);
 
         BadmintonRank rank = getBadmintonRank(participateA, participateB);


### PR DESCRIPTION
기존에 팀 등록시 중복 팀인지 확인하는 Validation은 작성자가 같은 팀과 팀의 타입이 있는지를 검사하였습니다.

![image](https://github.com/GSM-GOGO/GSM-GOGO-Server/assets/131235625/acadcb24-ed31-4d2b-a66b-82be3262dc42)
> 위와 같이

기존에는 한 학년, 과에 팀을 등록할 수 있는 권한인 학생이 한명 밖에 없기 때문에 괜찮지만 배드민턴은 모든 유저가 팀을 등록할 수 있어서

A가 B와 배드민턴 팀 등록, B가 C와 or C가 B와 배드민턴 팀 등록이 가능하는 이슈가 있었습니다

해당 이슈를 배드민턴 등록시 배드민턴 참여자를 조회하여 같은 유저가 있는지 검사하는 식으로 변경하였습니다.

추후에 필요성을 느낄 때 일반 경기도 이와 같이 변경할 수 있습니다. (단점 쿼리가 많이 나감)