### PR TITLE
CORS OPTIONS 메서드 요청 캐시 시간 설정

### DIFF
--- a/gsmgogo-api/src/main/java/team/gsmgogo/global/config/SecurityConfig.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/global/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"));
         config.setAllowedHeaders(Arrays.asList("*"));
         config.setExposedHeaders(Arrays.asList("*"));
+        config.setMaxAge(86400L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
요청시 마다 `OPTIONS` HTTP 메서드 요청이 계속 발생하는 문제를 해결하였습니다.

Options 메서드는 서버에 대한 허용된 통신 옵션을 요청하는 메서드 입니다.

현재 서버에서 발생하는 문제입니다.
- 페이지를 이동하면서 해당 페이지에 대한 리소스 요청을 하는데 요청 전에 허용된 메서드를 가져오기 위해 OPTIONS 메서드 요청을 보냅니다.
- 해당 사전 요청은 각각 무려 **500ms ~ 1000ms**의 지연시간이 걸리기 때문에 성능을 저하시킵니다.
- 해당 요청 응답의 헤더로 요청을 할 수 있는 메서드, 헤더 등의 정보를 받아옵니다.

`Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`

<img width="598" alt="스크린샷 2024-04-02 오전 11 41 02" src="https://github.com/GSM-GOGO/GSM-GOGO-Server/assets/131235625/8a378c27-add8-4cc3-b7f9-fb0ec891c91e">

## 해결

- 해당 사전 요청(preflight request)은 처음 한 번만 보낸 후에 그 이후의 요청에는 보낼 필요가 없습니다.
-  `OPTIONS` 메서드는 캐시를 할 수 있는데, `Access-Control-Max-Age` 헤더를 설정하여 캐시 시간을 설정할 수 있습니다.

- 로컬에서 요청 -> 페이지 이동 -> 요청 -> 페이지 이동 순으로 요청을 해보면 
- 각 요청마다 요청전에 `OPTIONS` 메서드 요청이 보내지는 것을 볼 수 있습니다.

<img width="739" alt="스크린샷 2024-04-02 오전 11 26 54" src="https://github.com/GSM-GOGO/GSM-GOGO-Server/assets/131235625/3a601afd-de35-4dff-b18e-c3c46267913e">

```
config.setMaxAge(86400L);
```
- 이렇게 maxAge의 시간을 늘려서 캐시 시간을 길게 설정해두어 해결하였습니다.
- 그 이후로는 첫 요청에만 사전요청을 보내고 그 이후에는 발생하지 않는 것을 볼 수 있습니다.

<img width="725" alt="스크린샷 2024-04-02 오전 11 27 29" src="https://github.com/GSM-GOGO/GSM-GOGO-Server/assets/131235625/b32b76ef-808a-4c93-b21f-0797d3b42592">



