### PR TITLE
포매이션 조회시 발생하는 불필요한 쿼리 개선 N+1

### DIFF
--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFormationGetServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFormationGetServiceImpl.java
@@ -10,20 +10,15 @@ import team.gsmgogo.domain.team.controller.dto.response.TeamFormationResponse;
 import team.gsmgogo.domain.team.entity.TeamEntity;
 import team.gsmgogo.domain.team.repository.TeamRepository;
 import team.gsmgogo.domain.team.service.TeamFormationGetService;
-import team.gsmgogo.domain.teamparticipate.entity.TeamParticipateEntity;
-import team.gsmgogo.domain.teamparticipate.repository.TeamParticipateJpaRepository;
 import team.gsmgogo.domain.user.entity.UserEntity;
 import team.gsmgogo.domain.user.enums.ClassEnum;
 import team.gsmgogo.global.exception.error.ExpectedException;
 import team.gsmgogo.global.facade.UserFacade;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class TeamFormationGetServiceImpl implements TeamFormationGetService {
     private final TeamRepository teamRepository;
-    private final TeamParticipateJpaRepository teamParticipateJpaRepository;
     private final UserFacade userFacade;
 
     @Override
@@ -34,8 +29,6 @@ public class TeamFormationGetServiceImpl implements TeamFormationGetService {
         TeamEntity team = teamRepository.findById(Long.valueOf(teamId))
             .orElseThrow(() -> new ExpectedException("해당 팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
-        List<TeamParticipateEntity> participateList = teamParticipateJpaRepository.findByTeamTeamId(team.getTeamId());
-
         return new TeamFormationResponse(
             team.getTeamId(),
             team.getTeamName(),
@@ -44,7 +37,7 @@ public class TeamFormationGetServiceImpl implements TeamFormationGetService {
             toTeamClassType(team.getTeamClass()),
             team.getAuthor().getUserId().equals(currentUser.getUserId()),
             team.getWinCount(),
-            participateList.stream().map(teamParticipate -> new FormationParticipateDto(
+                team.getTeamParticipates().stream().map(teamParticipate -> new FormationParticipateDto(
                 teamParticipate.getUser().getUserId(),
                 teamParticipate.getUser().getUserName(),
                 teamParticipate.getPositionX(),

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFormationGetServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/team/service/impl/TeamFormationGetServiceImpl.java
@@ -8,7 +8,7 @@ import team.gsmgogo.domain.team.controller.dto.response.FormationParticipateDto;
 import team.gsmgogo.domain.team.controller.dto.response.TeamClassType;
 import team.gsmgogo.domain.team.controller.dto.response.TeamFormationResponse;
 import team.gsmgogo.domain.team.entity.TeamEntity;
-import team.gsmgogo.domain.team.repository.TeamJpaRepository;
+import team.gsmgogo.domain.team.repository.TeamRepository;
 import team.gsmgogo.domain.team.service.TeamFormationGetService;
 import team.gsmgogo.domain.teamparticipate.entity.TeamParticipateEntity;
 import team.gsmgogo.domain.teamparticipate.repository.TeamParticipateJpaRepository;
@@ -22,7 +22,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class TeamFormationGetServiceImpl implements TeamFormationGetService {
-    private final TeamJpaRepository teamJpaRepository;
+    private final TeamRepository teamRepository;
     private final TeamParticipateJpaRepository teamParticipateJpaRepository;
     private final UserFacade userFacade;
 
@@ -31,7 +31,7 @@ public class TeamFormationGetServiceImpl implements TeamFormationGetService {
     public TeamFormationResponse execute(String teamId) {
         UserEntity currentUser = userFacade.getCurrentUser();
 
-        TeamEntity team = teamJpaRepository.findByTeamId(Long.valueOf(teamId))
+        TeamEntity team = teamRepository.findById(Long.valueOf(teamId))
             .orElseThrow(() -> new ExpectedException("해당 팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         List<TeamParticipateEntity> participateList = teamParticipateJpaRepository.findByTeamTeamId(team.getTeamId());

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamQueryDslRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamQueryDslRepository.java
@@ -1,0 +1,27 @@
+package team.gsmgogo.domain.team.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.gsmgogo.domain.team.entity.TeamEntity;
+
+import static team.gsmgogo.domain.team.entity.QTeamEntity.teamEntity;
+import static team.gsmgogo.domain.teamparticipate.entity.QTeamParticipateEntity.teamParticipateEntity;
+import static team.gsmgogo.domain.user.entity.QUserEntity.userEntity;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamQueryDslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Optional<TeamEntity> findByTeamId(Long timeId) {
+        return Optional.ofNullable(jpaQueryFactory.selectFrom(teamEntity)
+                .join(teamEntity.teamParticipates, teamParticipateEntity).fetchJoin()
+                .join(teamParticipateEntity.user, userEntity).fetchJoin()
+                .where(teamEntity.teamId.eq(timeId))
+                .fetchOne());
+    }
+
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamRepository.java
@@ -1,0 +1,10 @@
+package team.gsmgogo.domain.team.repository;
+
+import team.gsmgogo.domain.team.entity.TeamEntity;
+import java.util.Optional;
+
+public interface TeamRepository {
+
+    Optional<TeamEntity> findById(Long teamId);
+
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamRepositoryImpl.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamRepositoryImpl.java
@@ -1,0 +1,19 @@
+package team.gsmgogo.domain.team.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.gsmgogo.domain.team.entity.TeamEntity;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamRepositoryImpl implements TeamRepository {
+
+    private final TeamJpaRepository teamJpaRepository;
+
+    @Override
+    public Optional<TeamEntity> findById(Long teamId) {
+        return teamJpaRepository.findByTeamId(teamId);
+    }
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamRepositoryImpl.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/team/repository/TeamRepositoryImpl.java
@@ -10,10 +10,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TeamRepositoryImpl implements TeamRepository {
 
-    private final TeamJpaRepository teamJpaRepository;
+//    private final TeamJpaRepository teamJpaRepository;
+    private final TeamQueryDslRepository teamQueryDslRepository;
 
     @Override
     public Optional<TeamEntity> findById(Long teamId) {
-        return teamJpaRepository.findByTeamId(teamId);
+        return teamQueryDslRepository.findByTeamId(teamId);
     }
 }


### PR DESCRIPTION
현재 *포매이션 조회시(팀 조회) 해당 팀에 속해있는 유저의 수 만큼 조회 쿼리가 나가는 **N+1 현상**이 발생합니다.

- 팀 조회시 `팀 조회` + `팀 참여자들 조회` + `팀 참여자들을 순회하면서 각 유저 조회` 과정이 발생합니다.
   - 이렇게 `1 + 1 + N` 의 쿼리가 나가게 됩니다.

- 현재 모든 연관관계가 엔티티에 페치 타입이 `LAZY`로 설정되어있지만 연관관계로 맺어있는 엔티티에 조회하는 작업이 포함되어있어 N+1 현상이 발생합니다.

해당 이슈를 `queryDsl`을 활용하여 `fetch join`을 사용하여 필요한 엔티티를 한방쿼리로 불러와 이슈를 해결하였습니다.

---

### 예시: 문제점

> 쿼리가 길어 생략한 부분이 존재합니다.

```sql
Hibernate: 
    /* <criteria> */ select
		    Columns ...
    from
        user ue1_0 

-- 인증 과정에서 유저 조회
     
Hibernate: 
    /* <criteria> */ select
		    Columns ...
    from
        user ue1_0 
        
-- 현재 인증된 유저 조회
   
Hibernate: 
    /* <criteria> */ select
		    Columns ...
    from
        team te1_0 
        
 -- team_id로 팀 엔티티 조회
        
Hibernate: 
    /* <criteria> */ select
		    Columns ...
    from
        team_participate tpe1_0 
        
-- team_id로 팀 참가자 조회
        
Hibernate: 
    select
		    Columns ...
    from
        user ue1_0 
        
Hibernate: 
    select
		    Columns ...
    from
        user ue1_0 
        

-- 조회한 팀 참가자를 순회하면서 유저 조회 (2회)
```

- 이렇게 유저 수가 늘어날 수록 해당 유저 수 만큼의 추가 쿼리가 발생합니다.

만약 팀에 10명의 참가자가 있다면
- 해당 `team` 조회 1건
- `team_participate` (팀 참가자) 조회 1건
- `user` 10건

이렇게 총 12건의 쿼리가 생기게 됩니다.

### 예시: 해결

해당 현상을 `LAZY` 페치 타입인 `팀 참가자`, `유저`에 대한 엔티티를 처음 쿼리를 할 때 페치조인 하여 미리 값을 받아 놓는 방식으로 개선하였습니다.

```sql
Hibernate: 
    /* <criteria> */ select
		   Columns ...
    from
        user ue1_0 
    where
        ue1_0.user_id=?

-- 인증 과정에서 유저 조회
        
Hibernate: 
    /* <criteria> */ select
	    Columns ...
    from
        user ue1_0 
    where
        ue1_0.user_id=?
        
-- 현재 인증된 유저 조회
        
Hibernate: 
    /* select
        teamEntity 
    from
        TeamEntity teamEntity   
    inner join
        
    fetch
        teamEntity.teamParticipates as teamParticipateEntity   
    inner join
        
    fetch
        teamParticipateEntity.user as userEntity 
    where
        teamEntity.teamId = ?1 */ select
		        (team, team_participate, user) Columns ...
        from
            team te1_0 
        join
            team_participate tp1_0 
                on te1_0.team_id=tp1_0.team_id 
        join
            user u1_0 
                on u1_0.user_id=tp1_0.user_id 
        where
            te1_0.team_id=?
```

해당 문제를 `queryDsl`의 `fetch join` 을 활용하여 `team`→ `team_participate` → `user` 세 엔티티를 한방 쿼리로 해결하여 조회 성능을 개선하였습니다.