### PR TITLE
미니게임, 데일리룰렛 횟수 초기화 스케줄

### DIFF
--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
@@ -15,7 +15,7 @@ import team.gsmgogo.domain.user.repository.UserQueryDslRepository;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-public class ResetLoginCountJob {
+public class ResetCountJob {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final UserQueryDslRepository userQueryDslRepository;
@@ -29,7 +29,7 @@ public class ResetLoginCountJob {
 
     @Bean
     public Step resetCountStep(JobRepository jobRepository, PlatformTransactionManager platformTransactionManager){
-        return new StepBuilder("reset-count-step", jobRepository)
+        return new StepBuilder("reset-sms-count-step", jobRepository)
             .tasklet((contribution, chunkContext) -> {
                 userQueryDslRepository.bulkResetVerifyCount();
                 return RepeatStatus.FINISHED;

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
@@ -22,8 +22,8 @@ public class ResetCountJob {
     private final UserQueryDslRepository userQueryDslRepository;
     private final GameQueryDslRepository gameQueryDslRepository;
 
-    @Bean(name = "resetCountJob")
-    public Job resetCountJob(){
+    @Bean(name = "resetJob")
+    public Job resetJob(){
         return new JobBuilder("reset-count-Job", jobRepository)
             .start(resetSmsCountStep(jobRepository, platformTransactionManager))
             .next(resetGameCountStep(jobRepository, platformTransactionManager))

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
@@ -23,12 +23,13 @@ public class ResetCountJob {
     @Bean(name = "resetCountJob")
     public Job resetCountJob(){
         return new JobBuilder("reset-count-Job", jobRepository)
-            .start(resetCountStep(jobRepository, platformTransactionManager))
+            .start(resetSmsCountStep(jobRepository, platformTransactionManager))
+            .next(resetGameCountStep(jobRepository, platformTransactionManager))
             .build();
     }
 
     @Bean
-    public Step resetCountStep(JobRepository jobRepository, PlatformTransactionManager platformTransactionManager){
+    public Step resetSmsCountStep(JobRepository jobRepository, PlatformTransactionManager platformTransactionManager){
         return new StepBuilder("reset-sms-count-step", jobRepository)
             .tasklet((contribution, chunkContext) -> {
                 userQueryDslRepository.bulkResetVerifyCount();
@@ -36,5 +37,15 @@ public class ResetCountJob {
             },
             platformTransactionManager)
             .build();
+    }
+
+    @Bean
+    public Step resetGameCountStep(JobRepository jobRepository, PlatformTransactionManager platformTransactionManager){
+        return new StepBuilder("reset-game-count-step", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                            return RepeatStatus.FINISHED;
+                        },
+                        platformTransactionManager)
+                .build();
     }
 }

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/ResetCountJob.java
@@ -10,6 +10,7 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+import team.gsmgogo.domain.game.repository.GameQueryDslRepository;
 import team.gsmgogo.domain.user.repository.UserQueryDslRepository;
 
 @Slf4j
@@ -19,6 +20,7 @@ public class ResetCountJob {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final UserQueryDslRepository userQueryDslRepository;
+    private final GameQueryDslRepository gameQueryDslRepository;
 
     @Bean(name = "resetCountJob")
     public Job resetCountJob(){
@@ -43,6 +45,7 @@ public class ResetCountJob {
     public Step resetGameCountStep(JobRepository jobRepository, PlatformTransactionManager platformTransactionManager){
         return new StepBuilder("reset-game-count-step", jobRepository)
                 .tasklet((contribution, chunkContext) -> {
+                            gameQueryDslRepository.bulkResetGameCount();
                             return RepeatStatus.FINISHED;
                         },
                         platformTransactionManager)

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
@@ -30,14 +30,14 @@ public class ResetScheduler {
     private final UserQueryDslRepository userQueryDslRepository;
     private final GameQueryDslRepository gameQueryDslRepository;
 
-    @Scheduled(cron = "0 30 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void reset() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
         Map<String, JobParameter<?>> confMap = new HashMap<>();
         confMap.put("time", new JobParameter(System.currentTimeMillis(), String.class));
         JobParameters jobParameters = new JobParameters(confMap);
 
         jobLauncher.run(
-            new ResetCountJob(jobRepository, platformTransactionManager, userQueryDslRepository, gameQueryDslRepository).resetCountJob(),
+            new ResetCountJob(jobRepository, platformTransactionManager, userQueryDslRepository, gameQueryDslRepository).resetJob(),
             jobParameters
         );
     }

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
@@ -13,6 +13,7 @@ import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
+import team.gsmgogo.domain.game.repository.GameQueryDslRepository;
 import team.gsmgogo.domain.user.repository.UserQueryDslRepository;
 import team.gsmgogo.job.ResetCountJob;
 
@@ -27,6 +28,7 @@ public class ResetScheduler {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final UserQueryDslRepository userQueryDslRepository;
+    private final GameQueryDslRepository gameQueryDslRepository;
 
     @Scheduled(cron = "0 30 0 * * *")
     public void reset() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
@@ -35,7 +37,7 @@ public class ResetScheduler {
         JobParameters jobParameters = new JobParameters(confMap);
 
         jobLauncher.run(
-            new ResetCountJob(jobRepository, platformTransactionManager, userQueryDslRepository).resetCountJob(),
+            new ResetCountJob(jobRepository, platformTransactionManager, userQueryDslRepository, gameQueryDslRepository).resetCountJob(),
             jobParameters
         );
     }

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
@@ -14,7 +14,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 import team.gsmgogo.domain.user.repository.UserQueryDslRepository;
-import team.gsmgogo.job.ResetLoginCountJob;
+import team.gsmgogo.job.ResetCountJob;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,20 +22,20 @@ import java.util.Map;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ResetLoginCountScheduler {
+public class ResetScheduler {
     private final JobLauncher jobLauncher;
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final UserQueryDslRepository userQueryDslRepository;
 
     @Scheduled(cron = "0 5 1 * * *")
-    public void resetLoginCount() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+    public void reset() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
         Map<String, JobParameter<?>> confMap = new HashMap<>();
         confMap.put("time", new JobParameter(System.currentTimeMillis(), String.class));
         JobParameters jobParameters = new JobParameters(confMap);
 
         jobLauncher.run(
-            new ResetLoginCountJob(jobRepository, platformTransactionManager, userQueryDslRepository).resetCountJob(),
+            new ResetCountJob(jobRepository, platformTransactionManager, userQueryDslRepository).resetCountJob(),
             jobParameters
         );
     }

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ResetScheduler.java
@@ -28,7 +28,7 @@ public class ResetScheduler {
     private final PlatformTransactionManager platformTransactionManager;
     private final UserQueryDslRepository userQueryDslRepository;
 
-    @Scheduled(cron = "0 5 1 * * *")
+    @Scheduled(cron = "0 30 0 * * *")
     public void reset() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
         Map<String, JobParameter<?>> confMap = new HashMap<>();
         confMap.put("time", new JobParameter(System.currentTimeMillis(), String.class));

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/game/repository/GameQueryDslRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/game/repository/GameQueryDslRepository.java
@@ -1,0 +1,19 @@
+package team.gsmgogo.domain.game.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import static team.gsmgogo.domain.game.entity.QGameEntity.gameEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class GameQueryDslRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public void bulkResetGameCount() {
+        queryFactory.update(gameEntity)
+                    .set(gameEntity.coinToss, 0)
+                    .set(gameEntity.dailyRoulette, false)
+                .execute();
+    }
+}


### PR DESCRIPTION
## 개요
미니게임, 데일리룰렛의 횟수 초기화 스케줄러를 작성하였습니다.

## 작업내용
- 기존 전화번호 인증 횟수 스케줄러 Job에 Step을 추가하여 `Game` 엔티티의 횟수를 초기화 하였습니다.
- query dsl을 활용하여 벌크 쿼리를 날려 한방 쿼리로 모든 `Game` 테이블의 인스턴스를 초기화 하였습니다.