### PR TITLE
버튼게임 기능 추가

### DIFF
--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/controller/GameController.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/controller/GameController.java
@@ -1,14 +1,15 @@
 package team.gsmgogo.domain.game.controller;
 
-import feign.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.gsmgogo.domain.game.controller.dto.request.ButtonGameRequest;
 import team.gsmgogo.domain.game.controller.dto.request.CoinRequest;
 import team.gsmgogo.domain.game.controller.dto.response.CoinCountResponse;
 import team.gsmgogo.domain.game.controller.dto.response.CoinResponse;
 import team.gsmgogo.domain.game.controller.dto.response.DailyRouletteResponse;
+import team.gsmgogo.domain.game.service.ButtonGameService;
 import team.gsmgogo.domain.game.service.CoinTossCountService;
 import team.gsmgogo.domain.game.service.CoinTossService;
 import team.gsmgogo.domain.game.service.DailyRouletteRollService;
@@ -17,9 +18,11 @@ import team.gsmgogo.domain.game.service.DailyRouletteRollService;
 @RequiredArgsConstructor
 @RequestMapping("/game")
 public class GameController {
+
     private final CoinTossService coinTossService;
     private final DailyRouletteRollService dailyRouletteRollService;
     private final CoinTossCountService coinTossCountService;
+    private final ButtonGameService buttonGameService;
 
     @PostMapping("/roulette")
     public ResponseEntity<DailyRouletteResponse> dailyRouletteRoll() {
@@ -27,7 +30,7 @@ public class GameController {
     }
 
     @PostMapping("/coin")
-    public ResponseEntity<CoinResponse> coinToss(@RequestBody @Valid CoinRequest coinRequest){
+    public ResponseEntity<CoinResponse> coinToss(@RequestBody @Valid CoinRequest coinRequest) {
         return ResponseEntity.ok(coinTossService.execute(coinRequest));
     }
 
@@ -35,4 +38,11 @@ public class GameController {
     public ResponseEntity<CoinCountResponse> coinCount() {
         return ResponseEntity.ok(new CoinCountResponse(coinTossCountService.coinTossCount()));
     }
+
+    @PostMapping("/button")
+    public ResponseEntity<Void> clickButton(@RequestBody ButtonGameRequest buttonGameRequest) {
+        buttonGameService.execute(buttonGameRequest);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/controller/dto/request/ButtonGameRequest.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/controller/dto/request/ButtonGameRequest.java
@@ -1,0 +1,18 @@
+package team.gsmgogo.domain.game.controller.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.gsmgogo.domain.buttongame.enums.ButtonType;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ButtonGameRequest {
+    @NotNull
+    private ButtonType buttonType;
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/service/ButtonGameService.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/service/ButtonGameService.java
@@ -1,0 +1,7 @@
+package team.gsmgogo.domain.game.service;
+
+import team.gsmgogo.domain.game.controller.dto.request.ButtonGameRequest;
+
+public interface ButtonGameService {
+    void execute(ButtonGameRequest request);
+}

--- a/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/service/impl/ButtonGameServiceImpl.java
+++ b/gsmgogo-api/src/main/java/team/gsmgogo/domain/game/service/impl/ButtonGameServiceImpl.java
@@ -1,0 +1,47 @@
+package team.gsmgogo.domain.game.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+import team.gsmgogo.domain.buttongame.entity.ButtonGameEntity;
+import team.gsmgogo.domain.buttongame.repository.ButtonGameRepository;
+import team.gsmgogo.domain.buttongameparticipate.entity.ButtonGameParticipate;
+import team.gsmgogo.domain.buttongameparticipate.repository.ButtonGameParticipateRepository;
+import team.gsmgogo.domain.game.controller.dto.request.ButtonGameRequest;
+import team.gsmgogo.domain.game.service.ButtonGameService;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.global.exception.error.ExpectedException;
+import team.gsmgogo.global.facade.UserFacade;
+
+@Service
+@RequiredArgsConstructor
+public class ButtonGameServiceImpl implements ButtonGameService {
+
+    private final UserFacade userFacade;
+    private final ButtonGameRepository buttonGameRepository;
+    private final ButtonGameParticipateRepository buttonGameParticipateRepository;
+
+    @Override
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public void execute(ButtonGameRequest request) {
+
+        UserEntity currentUser = userFacade.getCurrentUser();
+
+        ButtonGameEntity buttonGame = buttonGameRepository.findByIsActiveIsTrue()
+                .orElseThrow(() -> new ExpectedException("버튼 게임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (buttonGameParticipateRepository.existsByButtonGameAndUser(buttonGame, currentUser))
+            throw new ExpectedException("이미 버튼을 눌렀습니다.", HttpStatus.BAD_REQUEST);
+
+        ButtonGameParticipate buttonGameParticipate = ButtonGameParticipate.builder()
+                .buttonGame(buttonGame)
+                .user(currentUser)
+                .buttonType(request.getButtonType())
+                .build();
+
+        buttonGameParticipateRepository.save(buttonGameParticipate);
+    }
+
+}

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/ButtonGameJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/ButtonGameJob.java
@@ -1,0 +1,28 @@
+package team.gsmgogo.job;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class ButtonGameJob {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+
+    // 현재 진행중인 버튼 게임 조회
+    // 해당 버튼 게임의 참여자들의 수를 타입 별로 조회
+
+    // 가장 인원이 적은 버튼을 선별 <- 가장 버튼의 타입 필요
+
+    // 해당 버튼을 선택한 유저들에게 200만원을 분배 <- 해당 타입의 유저들의 list가 필요
+
+    // 버튼 게임의 win_type에 해당 버튼 타입을 등록
+    // 버튼 게임읠 Is_active를 false로 변경
+    // 새로운 버튼게임을 등록
+
+
+
+}

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
@@ -32,17 +32,6 @@ public class CalculateButtonGameJob {
     private final UserJpaRepository userJpaRepository;
     private final ButtonGameParticipateQueryDslRepository buttonGameParticipateQueryDslRepository;
 
-    // 현재 진행중인 버튼 게임 조회
-    // 해당 버튼 게임의 참여자들의 수를 타입 별로 조회
-
-    // 가장 인원이 적은 버튼을 선별 <- 가장 버튼의 타입 필요
-
-    // 해당 버튼을 선택한 유저들에게 200만원을 분배 <- 해당 타입의 유저들의 list가 필요
-
-    // 버튼 게임의 win_type에 해당 버튼 타입을 등록
-    // 버튼 게임읠 Is_active를 false로 변경
-    // 새로운 버튼게임을 등록
-
     private final Integer TOTAL_POINT = 2000000;
 
     @Bean(name = "calculateButtonGameJob")

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
@@ -2,13 +2,25 @@ package team.gsmgogo.job;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.transaction.PlatformTransactionManager;
+import team.gsmgogo.domain.buttongame.entity.ButtonGameEntity;
+import team.gsmgogo.domain.buttongame.enums.ButtonType;
 import team.gsmgogo.domain.buttongame.repository.ButtonGameRepository;
 import team.gsmgogo.domain.buttongameparticipate.repository.ButtonGameParticipateQueryDslRepository;
+import team.gsmgogo.domain.buttongameparticipate.repository.dto.ButtonGameResultDto;
+import team.gsmgogo.domain.user.entity.UserEntity;
+import team.gsmgogo.domain.user.repository.UserJpaRepository;
+
+import java.util.List;
+import java.util.Map;
 
 @Configuration
 @RequiredArgsConstructor
@@ -17,6 +29,7 @@ public class CalculateButtonGameJob {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
     private final ButtonGameRepository buttonGameRepository;
+    private final UserJpaRepository userJpaRepository;
     private final ButtonGameParticipateQueryDslRepository buttonGameParticipateQueryDslRepository;
 
     // 현재 진행중인 버튼 게임 조회
@@ -30,9 +43,45 @@ public class CalculateButtonGameJob {
     // 버튼 게임읠 Is_active를 false로 변경
     // 새로운 버튼게임을 등록
 
+    private final Integer TOTAL_POINT = 2000000;
+
     @Bean(name = "calculateButtonGameJob")
     public Job calculateButtonGameJob(){
         return new JobBuilder("calculate-button-game-job", jobRepository)
+                .start(calculateButtonGameStep(jobRepository, platformTransactionManager))
+                .build();
+    }
+
+    @Bean
+    public Step calculateButtonGameStep(JobRepository jobRepository, PlatformTransactionManager platformTransactionManager){
+        return new StepBuilder("calculate-button-game-step", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+
+                            ButtonGameEntity buttonGame = buttonGameRepository.findByIsActiveIsTrue()
+                                    .orElseThrow(RuntimeException::new);
+
+                            ButtonGameResultDto buttonGameResultDto = buttonGameParticipateQueryDslRepository
+                                    .findWinUserList(buttonGame);
+
+                            ButtonType winType = buttonGameResultDto.getWinType();
+                            List<UserEntity> winUserList = buttonGameResultDto.getWinUserList();
+
+                            Integer ADD_POINT = (int) Math.ceil((double) TOTAL_POINT / winUserList.size());
+                            winUserList.forEach(user -> user.addPoint(ADD_POINT));
+                            userJpaRepository.saveAll(winUserList);
+
+                            buttonGame.setWinType(winType);
+                            buttonGame.endGame();
+
+                            buttonGameRepository.save(
+                                    ButtonGameEntity.builder()
+                                            .isActive(true)
+                                            .build()
+                            );
+
+                            return RepeatStatus.FINISHED;
+                        },
+                        platformTransactionManager)
                 .build();
     }
 

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
@@ -1,16 +1,23 @@
 package team.gsmgogo.job;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+import team.gsmgogo.domain.buttongame.repository.ButtonGameRepository;
+import team.gsmgogo.domain.buttongameparticipate.repository.ButtonGameParticipateQueryDslRepository;
 
 @Configuration
 @RequiredArgsConstructor
-public class ButtonGameJob {
+public class CalculateButtonGameJob {
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager platformTransactionManager;
+    private final ButtonGameRepository buttonGameRepository;
+    private final ButtonGameParticipateQueryDslRepository buttonGameParticipateQueryDslRepository;
 
     // 현재 진행중인 버튼 게임 조회
     // 해당 버튼 게임의 참여자들의 수를 타입 별로 조회
@@ -23,6 +30,10 @@ public class ButtonGameJob {
     // 버튼 게임읠 Is_active를 false로 변경
     // 새로운 버튼게임을 등록
 
-
+    @Bean(name = "calculateButtonGameJob")
+    public Job calculateButtonGameJob(){
+        return new JobBuilder("calculate-button-game-job", jobRepository)
+                .build();
+    }
 
 }

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
@@ -19,6 +19,7 @@ import team.gsmgogo.domain.buttongameparticipate.repository.dto.ButtonGameResult
 import team.gsmgogo.domain.user.entity.UserEntity;
 import team.gsmgogo.domain.user.repository.UserJpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -34,7 +35,7 @@ public class CalculateButtonGameJob {
 
     private final Integer TOTAL_POINT = 2000000;
 
-    @Bean(name = "calculateButtonGameJob")
+    @Bean(name = "buttonGameCalculateJob")
     public Job calculateButtonGameJob(){
         return new JobBuilder("calculate-button-game-job", jobRepository)
                 .start(calculateButtonGameStep(jobRepository, platformTransactionManager))
@@ -62,9 +63,12 @@ public class CalculateButtonGameJob {
                             buttonGame.setWinType(winType);
                             buttonGame.endGame();
 
+                            buttonGameRepository.save(buttonGame);
+
                             buttonGameRepository.save(
                                     ButtonGameEntity.builder()
                                             .isActive(true)
+                                            .createDate(LocalDateTime.now())
                                             .build()
                             );
 

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/job/CalculateButtonGameJob.java
@@ -56,26 +56,35 @@ public class CalculateButtonGameJob {
                             ButtonType winType = buttonGameResultDto.getWinType();
                             List<UserEntity> winUserList = buttonGameResultDto.getWinUserList();
 
-                            Integer ADD_POINT = (int) Math.ceil((double) TOTAL_POINT / winUserList.size());
-                            winUserList.forEach(user -> user.addPoint(ADD_POINT));
-                            userJpaRepository.saveAll(winUserList);
-
-                            buttonGame.setWinType(winType);
-                            buttonGame.endGame();
-
-                            buttonGameRepository.save(buttonGame);
-
-                            buttonGameRepository.save(
-                                    ButtonGameEntity.builder()
-                                            .isActive(true)
-                                            .createDate(LocalDateTime.now())
-                                            .build()
-                            );
+                            addPointWinUser(winUserList);
+                            endGame(buttonGame, winType);
+                            addNewButtonGame();
 
                             return RepeatStatus.FINISHED;
                         },
                         platformTransactionManager)
                 .build();
+    }
+
+    private void addPointWinUser(List<UserEntity> winUserList) {
+        Integer ADD_POINT = (int) Math.ceil((double) TOTAL_POINT / winUserList.size());
+        winUserList.forEach(user -> user.addPoint(ADD_POINT));
+        userJpaRepository.saveAll(winUserList);
+    }
+
+    private void endGame(ButtonGameEntity buttonGame, ButtonType winType) {
+        buttonGame.setWinType(winType);
+        buttonGame.endGame();
+        buttonGameRepository.save(buttonGame);
+    }
+
+    private void addNewButtonGame() {
+        buttonGameRepository.save(
+                ButtonGameEntity.builder()
+                        .isActive(true)
+                        .createDate(LocalDateTime.now())
+                        .build()
+        );
     }
 
 }

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ButtonGameCalculateScheduler.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ButtonGameCalculateScheduler.java
@@ -1,7 +1,6 @@
 package team.gsmgogo.scheduler;
 
 import lombok.RequiredArgsConstructor;
-import org.quartz.Scheduler;
 import org.springframework.batch.core.JobParameter;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersInvalidException;
@@ -17,7 +16,6 @@ import team.gsmgogo.domain.buttongame.repository.ButtonGameRepository;
 import team.gsmgogo.domain.buttongameparticipate.repository.ButtonGameParticipateQueryDslRepository;
 import team.gsmgogo.domain.user.repository.UserJpaRepository;
 import team.gsmgogo.job.CalculateButtonGameJob;
-import team.gsmgogo.job.ResetCountJob;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ButtonGameCalculateScheduler.java
+++ b/gsmgogo-batch/src/main/java/team/gsmgogo/scheduler/ButtonGameCalculateScheduler.java
@@ -1,0 +1,53 @@
+package team.gsmgogo.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.quartz.Scheduler;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import team.gsmgogo.domain.buttongame.repository.ButtonGameRepository;
+import team.gsmgogo.domain.buttongameparticipate.repository.ButtonGameParticipateQueryDslRepository;
+import team.gsmgogo.domain.user.repository.UserJpaRepository;
+import team.gsmgogo.job.CalculateButtonGameJob;
+import team.gsmgogo.job.ResetCountJob;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ButtonGameCalculateScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+    private final ButtonGameRepository buttonGameRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final ButtonGameParticipateQueryDslRepository buttonGameParticipateQueryDslRepository;
+
+    @Scheduled(cron = "0 0 23 * * *")
+    public void start() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+
+        Map<String, JobParameter<?>> jobParametersMap = new HashMap<>();
+        jobParametersMap.put("button-game-time", new JobParameter(System.currentTimeMillis(), String.class));
+        JobParameters jobParameters = new JobParameters(jobParametersMap);
+
+        jobLauncher.run(
+                new CalculateButtonGameJob(
+                        jobRepository,
+                        platformTransactionManager,
+                        buttonGameRepository,
+                        userJpaRepository,
+                        buttonGameParticipateQueryDslRepository).calculateButtonGameJob(),
+                jobParameters
+        );
+    }
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
@@ -12,7 +12,8 @@ import team.gsmgogo.domain.buttongame.enums.ButtonType;
 @Getter
 @ToString
 public class ButtonGameEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "is_active")

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
@@ -29,4 +29,12 @@ public class ButtonGameEntity {
     @Column(name = "create_date")
     @CreatedDate
     private LocalDateTime createDate;
+
+    public void setWinType(ButtonType winType) {
+        this.winType = winType;
+    }
+
+    public void endGame() {
+        isActive = false;
+    }
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
@@ -2,7 +2,10 @@ package team.gsmgogo.domain.buttongame.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
 import team.gsmgogo.domain.buttongame.enums.ButtonType;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "button_game")
@@ -22,4 +25,8 @@ public class ButtonGameEntity {
     @Column(name = "win_type")
     @Enumerated(EnumType.STRING)
     private ButtonType winType;
+
+    @Column(name = "create_date")
+    @CreatedDate
+    private LocalDateTime createDate;
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/entity/ButtonGameEntity.java
@@ -1,0 +1,24 @@
+package team.gsmgogo.domain.buttongame.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import team.gsmgogo.domain.buttongame.enums.ButtonType;
+
+@Entity
+@Table(name = "button_game")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+public class ButtonGameEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @Column(name = "win_type")
+    @Enumerated(EnumType.STRING)
+    private ButtonType winType;
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/enums/ButtonType.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/enums/ButtonType.java
@@ -1,0 +1,17 @@
+package team.gsmgogo.domain.buttongame.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ButtonType {
+
+    ONE("ONE"),
+    TWO("TWO"),
+    THREE("THREE"),
+    FOUR("FOUR"),
+    FIVE("FIVE");
+
+    private final String type;
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/repository/ButtonGameRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/repository/ButtonGameRepository.java
@@ -3,5 +3,8 @@ package team.gsmgogo.domain.buttongame.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.gsmgogo.domain.buttongame.entity.ButtonGameEntity;
 
+import java.util.Optional;
+
 public interface ButtonGameRepository extends JpaRepository<ButtonGameEntity, Long> {
+    Optional<ButtonGameEntity> findByIsActiveIsTrue();
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/repository/ButtonGameRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongame/repository/ButtonGameRepository.java
@@ -1,0 +1,7 @@
+package team.gsmgogo.domain.buttongame.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.gsmgogo.domain.buttongame.entity.ButtonGameEntity;
+
+public interface ButtonGameRepository extends JpaRepository<ButtonGameEntity, Long> {
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/entity/ButtonGameParticipate.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/entity/ButtonGameParticipate.java
@@ -19,11 +19,11 @@ public class ButtonGameParticipate {
     private Long id;
 
     @ManyToOne
-    @Column(name = "button_game_id")
+    @JoinColumn(name = "button_game_id")
     private ButtonGameEntity buttonGame;
 
     @ManyToOne
-    @Column(name = "user_id")
+    @JoinColumn(name = "user_id")
     private UserEntity user;
 
     @Enumerated(EnumType.STRING)

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/entity/ButtonGameParticipate.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/entity/ButtonGameParticipate.java
@@ -1,0 +1,32 @@
+package team.gsmgogo.domain.buttongameparticipate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import team.gsmgogo.domain.buttongame.entity.ButtonGameEntity;
+import team.gsmgogo.domain.buttongame.enums.ButtonType;
+import team.gsmgogo.domain.user.entity.UserEntity;
+
+@Entity
+@Table(name = "button_game_participate")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@ToString
+public class ButtonGameParticipate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @Column(name = "button_game_id")
+    private ButtonGameEntity buttonGame;
+
+    @ManyToOne
+    @Column(name = "user_id")
+    private UserEntity user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "button_type")
+    private ButtonType buttonType;
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateQueryDslRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateQueryDslRepository.java
@@ -1,0 +1,50 @@
+package team.gsmgogo.domain.buttongameparticipate.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.gsmgogo.domain.buttongame.entity.ButtonGameEntity;
+import team.gsmgogo.domain.buttongame.enums.ButtonType;
+import team.gsmgogo.domain.buttongameparticipate.repository.dto.ButtonGameResultDto;
+import team.gsmgogo.domain.user.entity.UserEntity;
+
+import java.util.List;
+
+import static team.gsmgogo.domain.buttongameparticipate.entity.QButtonGameParticipate.buttonGameParticipate;
+
+@Repository
+@RequiredArgsConstructor
+public class ButtonGameParticipateQueryDslRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public ButtonGameResultDto findWinUserList(ButtonGameEntity buttonGame) {
+        ButtonType winType = findWinType(buttonGame);
+        List<UserEntity> winUserList = winUserList(buttonGame, winType);
+
+        return new ButtonGameResultDto(winType, winUserList);
+    }
+
+    private ButtonType findWinType(ButtonGameEntity buttonGame) {
+        return queryFactory
+                .select(buttonGameParticipate.buttonType)
+                .from(buttonGameParticipate)
+                .where(buttonGameParticipate.buttonGame.eq(buttonGame))
+                .groupBy(buttonGameParticipate.buttonType)
+                .orderBy(buttonGameParticipate.count().asc())
+                .fetchFirst();
+    }
+
+    private List<UserEntity> winUserList(ButtonGameEntity buttonGame, ButtonType winType) {
+        return queryFactory
+                .select(buttonGameParticipate.user)
+                .from(buttonGameParticipate)
+                .where(buttonGameParticipate.buttonGame.eq(buttonGame).and(
+                        buttonGameParticipate.buttonType.eq(winType))
+                ).fetch();
+    }
+
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateQueryDslRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateQueryDslRepository.java
@@ -42,8 +42,8 @@ public class ButtonGameParticipateQueryDslRepository {
         return queryFactory
                 .select(buttonGameParticipate.user)
                 .from(buttonGameParticipate)
-                .where(buttonGameParticipate.buttonGame.eq(buttonGame).and(
-                        buttonGameParticipate.buttonType.eq(winType))
+                .where(buttonGameParticipate.buttonGame.eq(buttonGame)
+                        .and(buttonGameParticipate.buttonType.eq(winType))
                 ).fetch();
     }
 

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateRepository.java
@@ -1,0 +1,7 @@
+package team.gsmgogo.domain.buttongameparticipate.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.gsmgogo.domain.buttongameparticipate.entity.ButtonGameParticipate;
+
+public interface ButtonGameParticipateRepository extends JpaRepository<ButtonGameParticipate, Long> {
+}

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateRepository.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/ButtonGameParticipateRepository.java
@@ -1,7 +1,10 @@
 package team.gsmgogo.domain.buttongameparticipate.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.gsmgogo.domain.buttongame.entity.ButtonGameEntity;
 import team.gsmgogo.domain.buttongameparticipate.entity.ButtonGameParticipate;
+import team.gsmgogo.domain.user.entity.UserEntity;
 
 public interface ButtonGameParticipateRepository extends JpaRepository<ButtonGameParticipate, Long> {
+    boolean existsByButtonGameAndUser(ButtonGameEntity buttonGame, UserEntity user);
 }

--- a/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/dto/ButtonGameResultDto.java
+++ b/gsmgogo-entity/src/main/java/team/gsmgogo/domain/buttongameparticipate/repository/dto/ButtonGameResultDto.java
@@ -1,0 +1,15 @@
+package team.gsmgogo.domain.buttongameparticipate.repository.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import team.gsmgogo.domain.buttongame.enums.ButtonType;
+import team.gsmgogo.domain.user.entity.UserEntity;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ButtonGameResultDto {
+    private ButtonType winType;
+    private List<UserEntity> winUserList;
+}


### PR DESCRIPTION
## 개요
버튼 게임 기능을 추가하였습니다

## 작업내용
- `ButtonGameEntity`, `ButtonGameParticipate` 엔티티를 생성하였습니다.
<img width="940" alt="image" src="https://github.com/GSM-GOGO/GSM-GOGO-Server/assets/131235625/7cecea8a-2c09-47de-a210-f572d1f18c27">

- `/game/button`: 유저는 1 ~ 5번 버튼 중 하나의 버튼을 누를 수 있습니다.
- 매일 오후 11시가 되면 `CalculateButtonGameJob`을 실행합니다.

- `CalculateButtonGameJob`은 현재 진행중인 버튼게임에서 가장 적게 눌려진 버튼을 누른 유저들에게 2,000,000 포인트를 나누어줍니다.
   - `ButtonGameParticipateQueryDslRepository`: 현재 버튼 게임에서 가장 적게 눌린 버튼의 종류와 해당 버튼을 누른 유저들의 리스트를 불러옵니다.
   - `calculateButtonGameStep`: 하나의 tasklet으로 구성되어 있으며, 현재 버튼게임 조회, 포인트 배분, 버튼게임 종료 및 새로운 버튼게임 생성의 작업을 수행합니다.